### PR TITLE
Add full set of ruff linting rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     rev: v5.0.0
     hooks:
     - id: trailing-whitespace
+      exclude: renv/activate.R
     - id: end-of-file-fixer
     - id: check-yaml
     - id: check-added-large-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,22 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
+# Enable all `pydocstyle` rules, limiting to those that adhere to the
+# Google convention via `convention = "google"`, below.
+select = [
+  "E", # pycodestyle
+  "F", # pyflakes
+  "D", # pydocstyle
+  "I", # isort
+  "UP", # pyupgrade
+  "RUF", # ruff-only checking
+  "NPY201", # Numpy 2.0.1
+]
+
+# On top of the Google convention, disable:
+ignore = [
+  "D202", # Blank line after docstring is ok
+  "D107", # Location of __init__ docstring in class not __init__"
+]


### PR DESCRIPTION
This PR tells the `ruff` linter to use a much broader set of code quality rules. The set that I've added is the full set used in the `virtual_ecosystem` repo. If this becomes too restrictive for the purposes of this repo we can deactivate certain rules