### PR TITLE
Model fungal-to-bacterial ratio

### DIFF
--- a/analysis/soil/fungal_bacteria_ratio/model.R
+++ b/analysis/soil/fungal_bacteria_ratio/model.R
@@ -1,0 +1,81 @@
+#' ---
+#' title: Descriptive name of the script
+#'
+#' description: |
+#'     Brief description of what the script does, its main purpose, and any important
+#'     scientific context. Keep it concise but informative.
+#'
+#'     This can include multiple paragraphs.
+#'
+#' VE_module: Soil
+#'
+#' author:
+#'   - name: Hao Ran Lai
+#'
+#' status: wip
+#'
+#' input_files:
+#'   - name: Input file name
+#'     path: Full file path on shared drive
+#'     description: |
+#'       Source (short citation) and a brief explanation of what this input file
+#'       contains and its use case in this script
+#'
+#' output_files:
+#'   - name: Output file name
+#'     path: Full file path on shared drive
+#'     description: |
+#'       What the output file contains and its significance, are they used in any other
+#'       scripts?
+#'
+#' package_dependencies:
+#'     - tools
+#'
+#' usage_notes: |
+#'   Any known issues or bugs? Future plans for script/extensions or improvements
+#'   planned that should be noted?
+#' ---
+
+library(tidyverse)
+library(readxl)
+library(glmmTMB)
+
+
+
+# Data --------------------------------------------------------------------
+
+# subplot coordinates
+coord <-
+  read_xlsx("data/primary/soil/fungal_bacteria_ratio/SAFE_Dataset.xlsx",
+    sheet = 2
+  ) %>%
+  filter(Type == "Carbon Subplot") %>%
+  rename(location_name = `Location name`)
+
+# PLFA concentrations containing fungal:bacterial ratio
+plfa <-
+  read_xlsx("data/primary/soil/fungal_bacteria_ratio/SAFE_Dataset.xlsx",
+    sheet = 5,
+    skip = 9
+  ) %>%
+  rename(FBR = `Fungal:Bacteria`) %>%
+  # join spatial coordinates and convert to glmmTMB-compatible class
+  left_join(coord) %>%
+  mutate(
+    pos = numFactor(Longitude, Latitude),
+    # dummy grouping variable for spatial modelling
+    group = factor(1)
+  )
+
+
+
+
+# Model -------------------------------------------------------------------
+
+mod <- glmmTMB(
+  FBR ~ 1 + exp(pos + 0 | group),
+  family = beta_family(link = "logit"),
+  data = plfa
+)
+
+summary(mod)

--- a/analysis/soil/fungal_bacteria_ratio/model.R
+++ b/analysis/soil/fungal_bacteria_ratio/model.R
@@ -30,7 +30,6 @@
 #'     - tidyverse
 #'     - readxl
 #'     - glmmTMB
-#'     - performance
 #'
 #' usage_notes: |
 #'   In the future, it is possible to get a numerically more accurate ratio
@@ -41,7 +40,6 @@
 library(tidyverse)
 library(readxl)
 library(glmmTMB)
-library(performance)
 
 
 

--- a/analysis/soil/fungal_bacteria_ratio/model.R
+++ b/analysis/soil/fungal_bacteria_ratio/model.R
@@ -1,11 +1,8 @@
 #' ---
-#' title: Descriptive name of the script
+#' title: Estimating fungal-to-bacteria ratio from SAFE data
 #'
 #' description: |
-#'     Brief description of what the script does, its main purpose, and any important
-#'     scientific context. Keep it concise but informative.
-#'
-#'     This can include multiple paragraphs.
+#'     This R script estimates fungal-to-bacteria ratio from SAFE data
 #'
 #' VE_module: Soil
 #'
@@ -15,11 +12,13 @@
 #' status: wip
 #'
 #' input_files:
-#'   - name: Input file name
-#'     path: Full file path on shared drive
+#'   - name: SAFE_Dataset.xlsx
+#'     path: data/primary/soil/fungal_bacteria_ratio
 #'     description: |
-#'       Source (short citation) and a brief explanation of what this input file
-#'       contains and its use case in this script
+#'       Soil and litter chemistry, soil microbial communities and
+#'       litter decomposition from tropical forest and oil palm dataset by
+#'       Elias Dafydd et al. from SAFE; downloaded from
+#'       https://doi.org/10.5281/zenodo.3929632
 #'
 #' output_files:
 #'   - name: Output file name
@@ -29,7 +28,9 @@
 #'       scripts?
 #'
 #' package_dependencies:
-#'     - tools
+#'     - tidyverse
+#'     - readxl
+#'     - glmmTMB
 #'
 #' usage_notes: |
 #'   Any known issues or bugs? Future plans for script/extensions or improvements
@@ -73,9 +74,18 @@ plfa <-
 # Model -------------------------------------------------------------------
 
 mod <- glmmTMB(
-  FBR ~ 1 + exp(pos + 0 | group),
+  FBR ~ 1 + (1 | Plot_ID),
   family = beta_family(link = "logit"),
   data = plfa
 )
 
 summary(mod)
+
+newdat <- data.frame(
+  Plot_ID = NA
+)
+predict(mod,
+  newdata = newdat,
+  allow.new.levels = TRUE,
+  type = "response"
+)


### PR DESCRIPTION
This PR estimates fungal-to-bacterial ratio using the SAFE dataset [here](https://zenodo.org/records/3929632).

Main points:
- There are various soil covariates but I ended up included only soil pH and moisture, because the soil nutrients (N, P and C) are highly collinear with soil moisture. 
- I did not model ratio, instead I modelled fungal and bacterial biomass (in terms of PLFA) first, and then predicted their ratio. This will future proof our analysis in case we want to model OTUs in a joint-species-distribution-model framework (one day we will have the OTU data available)
- The fungal-to-bacterial ratio is estimated to be 0.24 --- this value stay roughly the same regardless of my modelling decision.