### PR TITLE
Disable object_name_linter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: linters_with_defaults(
     cyclocomp_linter(complexity_limit = 10L),
     indentation_linter(indent = 2L),
-    line_length_linter(length = 88L)
+    line_length_linter(length = 88L),
+    object_name_linter = NULL
   )


### PR DESCRIPTION
This PR disables the `object_name_linter` option in `lintr` to relax the object name conventions --- we'll just need to make sure each of us are consistent from hereon!

