### PR TITLE
Update elevation script to use cell_id structure

### DIFF
--- a/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
+++ b/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
@@ -183,100 +183,65 @@ if np.isnan(dst_data).any():
     dst_data = filled_data
 
 # Reformat DEM to Virtual Ecosystem (VE) 1D grid structure
-# This section converts the processed elevation dataset from
-# a 2D spatial grid (x, y) into the VE cell-based format.
-# The elevation grid is flattened so that each spatial grid cell
-# is represented by a unique `cell_id`.
+# The original grid coordinates (cell_x, cell_y) represent projected
+# UTMcell-centre positions. To ensure consistency with VE inputs, these
+# coordinates are converted to distances relative to the grid origin
+# (cell centre based).This results in regularly spaced x and y coordinates
+# starting at 0 and increasing by the grid resolution.
+
 #
 # Final dataset structure:
 #   Dimensions:
-#       cell_id      → unique grid cell identifier (row-major order)
-#
-#   Coordinates per cell_id:
 #       x                   → distance from grid origin (m)
 #       y                   → distance from grid origin (m)
+#
+#   Coordinates:
 #       longitude_UTM50N    → UTM Zone 50N easting coordinate (m)
 #       latitude_UTM50N     → UTM Zone 50N northing coordinate (m)
 #
 #   Variables:
 #       elevation           → surface elevation of each grid cell (m)
 
-
-# Convert the absolute UTM coordinates into distances relative to the grid origin.
-# This ensures the grid coordinates start at zero, which simplifies indexing
-# and maintains consistency with the VE grid coordinate convention.
+# Convert projected coordinates to distance from grid origin
 x = cell_x - cell_x[0]
 y = cell_y - cell_y[0]
 
-# Extract the unique x and y coordinate values and sort them in ascending order.
+# Store original UTM coordinates from TOML as spatial references
+longitude_UTM50N = cell_x.astype(np.float32)  # UTM Easting (m)
+latitude_UTM50N = cell_y.astype(np.float32)  # UTM Northing (m)
+
+# This ensures that spatial positions are defined consistently and
+# independently of absolute map coordinates.
+
+# Explicit uniqueness and ordering of spatial coordinates
 x_unique = np.sort(np.unique(x))
 y_unique = np.sort(np.unique(y))
 
-# RasterIO reads raster arrays with dimensions ordered as (y, x).
-# Since the VE grid and some R-based workflows expect (x, y) ordering,
-# we transpose the raster to align with that coordinate orientation.
+# The unique and ordered x and y coordinate vectors define the spatial
+# dimensions of the dataset. Elevation values are stored as a 2D array with
+# dimensions (x, y). Because rasterio reads raster data in (y, x) order,
+# the array is transposed to (x, y)
 elevation_matrix = dst_data.T.astype(np.float32)
 
 
-# Determine the grid size from the elevation matrix dimensions.
-ny, nx = elevation_matrix.shape
+# Build xarray Dataset with x and y as spatial dimensions
+# The resulting dataset contains:
+#   - Dimensions: x and y in metres (distance from grid origin)
+#   - Coordinates: UTM Easting and Northing from the TOML grid definition
+#   - Variable: elevation in meters
 
-# The elevation matrix was previously transposed to match (x, y) ordering.
-# Here we transpose it back so that indexing follows the conventional
-# raster format where array indices correspond to [row (y), column (x)].
-elev = elevation_matrix.T  # back to (ny, nx)
-
-
-# The numbering follows row-major ordering, starting at the top-left
-# cell and increasing from left to right across each row.
-cell_ids = np.arange(nx * ny, dtype=np.int32).reshape(ny, nx)
-
-# No vertical flipping is required here.
-# The affine transform from the reprojection step already ensures that
-# the first row corresponds to the northernmost (top) part of the grid.
-
-# Convert the 2D cell_id grid into a 1D array.
-cell_id_flat = cell_ids.flatten()
-
-# Flatten the elevation grid to align with the 1D cell_id structure.
-elevation_flat = elev.flatten().astype(np.float32)
-
-# Compute the x and y distances again as float32 arrays.
-x_dist = (cell_x - cell_x[0]).astype(np.float32)
-y_dist = (cell_y - cell_y[0]).astype(np.float32)
-
-# Important note regarding the y coordinate orientation:
-# y_dist begins at zero at the southern boundary of the grid.
-# However, VE uses a top-left origin, so the y ordering must be reversed.
-
-# Expand the x and coordinate values so that each row of the grid
-# receives the same sequence of x distances.
-x_per_cell = np.tile(x_dist, ny)
-y_per_cell = np.repeat(y_dist[::-1], nx)
-
-# Generate the longitude and latitude values (UTM eastings) for each cell.
-# These coordinates represent the absolute UTM positions of
-# grid cell centres across the full grid extent.
-lon_per_cell = np.tile(cell_x, ny)
-lat_per_cell = np.repeat(cell_y[::-1], nx)
-
-# Construct the final xarray Dataset using a single cell_id dimension.
-# All spatial variables (elevation, coordinates, and positions)
-# are aligned with the flattened grid cell identifiers.
-dataset_cell = xr.Dataset(
-    {"elevation": ("cell_id", elevation_flat)},
+dataset_xy = xr.Dataset(
+    {"elevation": (("x", "y"), elevation_matrix)},
     coords={
-        "cell_id": ("cell_id", cell_id_flat),
-        "x": ("cell_id", x_per_cell),
-        "y": ("cell_id", y_per_cell),
-        "longitude_UTM50N": ("cell_id", lon_per_cell),
-        "latitude_UTM50N": ("cell_id", lat_per_cell),
+        "x": x_unique.astype(np.float32),
+        "y": y_unique.astype(np.float32),
+        "longitude_UTM50N": ("x", longitude_UTM50N),
+        "latitude_UTM50N": ("y", latitude_UTM50N),
     },
 )
 
-# Once the elevation dataset has been reprojected, resampled,
-# and validated, it is exported to a NetCDF file. This format
-# is required by the VE model for spatial inputs.
-dataset_cell.to_netcdf(output_filename)
+# Once we have reprojected, resampled, and validated the elevation dataset
+# (with all invalid values handled), we save the final result as a NetCDF file.
+dataset_xy.to_netcdf(output_filename)
 
-print(f"✅ Saved VE-style elevation (cell_id structure) to {output_filename}")
+print(f"✅ Saved resampled elevation ({res} m) to {output_filename}")

--- a/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
+++ b/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
@@ -99,17 +99,17 @@ from scipy import ndimage
 
 # Define input directory and filename for the SRTM dataset for the SAFE Project area,
 # covering the region 4°N 116°E to 5°N 117°E
-input_srtm = Path("../../../data/sites/SRTM_UTM50N_processed.tif")
+input_srtm = Path("../../../data/primary/SRTM_UTM50N_processed.tif")
 
 
 # Define the output directory and filename for the reprojected and spatially
 # interpolated elevation data to be used in the VE model
 output_dir = Path("../../../data/derived/abiotic/elevation_data")
 output_dir.mkdir(parents=True, exist_ok=True)
-output_filename = output_dir / "elevation_Maliau_2010_2020_UTM50N.nc"
+output_filename = output_dir / "elevation_maliau_2010_2020_UTM50N.nc"
 
 # Load the destination grid details
-with open("../../../sites/maliau_site_definition.toml", "rb") as f:
+with open("../../../sites/maliau_grid_definition_90m.toml", "rb") as f:
     site_config = tomllib.load(f)
 
 cell_x = np.array(site_config["cell_x_centres"])  # UTM eastings
@@ -180,46 +180,101 @@ if np.isnan(dst_data).any():
     filled_data[mask] = dst_data[tuple(nearest_index[:, mask])]
     dst_data = filled_data
 
-# After cleaning and resampling, we prepare the DEM in a structured dataset format.
-# The original grid coordinates (cell_x, cell_y) represent projected UTM
-# cell-centre positions. To ensure consistency with VE inputs, these coordinates are
-# converted to distances relative to the grid origin (cell centre based).
-# This results in regularly spaced x and y coordinates starting at 0 and increasing by
-# the grid resolution.
+# Reformat DEM to Virtual Ecosystem (VE) 1D grid structure
+# This section converts the processed elevation dataset from
+# a 2D spatial grid (x, y) into the VE cell-based format.
+# The elevation grid is flattened so that each spatial grid cell
+# is represented by a unique `cell_id`.
+#
+# Final dataset structure:
+#   Dimensions:
+#       cell_id      → unique grid cell identifier (row-major order)
+#
+#   Coordinates per cell_id:
+#       x                   → distance from grid origin (m)
+#       y                   → distance from grid origin (m)
+#       longitude_UTM50N    → UTM Zone 50N easting coordinate (m)
+#       latitude_UTM50N     → UTM Zone 50N northing coordinate (m)
+#
+#   Variables:
+#       elevation           → surface elevation of each grid cell (m)
 
-# Convert projected coordinates to distance from grid origin
+
+# Convert the absolute UTM coordinates into distances relative to the grid origin.
+# This ensures the grid coordinates start at zero, which simplifies indexing
+# and maintains consistency with the VE grid coordinate convention.
 x = cell_x - cell_x[0]
 y = cell_y - cell_y[0]
 
-# This ensures that spatial positions are defined consistently and
-# independently of absolute map coordinates.
-
-# Explicit uniqueness and ordering of spatial coordinates
+# Extract the unique x and y coordinate values and sort them in ascending order.
 x_unique = np.sort(np.unique(x))
 y_unique = np.sort(np.unique(y))
 
-# The unique and ordered x and y coordinate vectors define the spatial
-# dimensions of the dataset. Elevation values are stored as a 2D array with
-# dimensions (x, y). Because rasterio reads raster data in (y, x) order,
-# the array is transposed to (x, y)
+# RasterIO reads raster arrays with dimensions ordered as (y, x).
+# Since the VE grid and some R-based workflows expect (x, y) ordering,
+# we transpose the raster to align with that coordinate orientation.
 elevation_matrix = dst_data.T.astype(np.float32)
 
 
-# Build xarray Dataset with x and y as spatial dimensions
-# The resulting dataset contains:
-#   - Dimensions: x and y in metres (distance from grid origin)
-#   - Variable: elevation in meters
+# Determine the grid size from the elevation matrix dimensions.
+ny, nx = elevation_matrix.shape
 
-dataset_xy = xr.Dataset(
-    {"elevation": (("x", "y"), elevation_matrix)},
+# The elevation matrix was previously transposed to match (x, y) ordering.
+# Here we transpose it back so that indexing follows the conventional
+# raster format where array indices correspond to [row (y), column (x)].
+elev = elevation_matrix.T  # back to (ny, nx)
+
+
+# The numbering follows row-major ordering, starting at the top-left
+# cell and increasing from left to right across each row.
+cell_ids = np.arange(nx * ny, dtype=np.int32).reshape(ny, nx)
+
+# No vertical flipping is required here.
+# The affine transform from the reprojection step already ensures that
+# the first row corresponds to the northernmost (top) part of the grid.
+
+# Convert the 2D cell_id grid into a 1D array.
+cell_id_flat = cell_ids.flatten()
+
+# Flatten the elevation grid to align with the 1D cell_id structure.
+elevation_flat = elev.flatten().astype(np.float32)
+
+# Compute the x and y distances again as float32 arrays.
+x_dist = (cell_x - cell_x[0]).astype(np.float32)
+y_dist = (cell_y - cell_y[0]).astype(np.float32)
+
+# Important note regarding the y coordinate orientation:
+# y_dist begins at zero at the southern boundary of the grid.
+# However, VE uses a top-left origin, so the y ordering must be reversed.
+
+# Expand the x and coordinate values so that each row of the grid
+# receives the same sequence of x distances.
+x_per_cell = np.tile(x_dist, ny)
+y_per_cell = np.repeat(y_dist[::-1], nx)
+
+# Generate the longitude and latitude values (UTM eastings) for each cell.
+# These coordinates represent the absolute UTM positions of
+# grid cell centres across the full grid extent.
+lon_per_cell = np.tile(cell_x, ny)
+lat_per_cell = np.repeat(cell_y[::-1], nx)
+
+# Construct the final xarray Dataset using a single cell_id dimension.
+# All spatial variables (elevation, coordinates, and positions)
+# are aligned with the flattened grid cell identifiers.
+dataset_cell = xr.Dataset(
+    {"elevation": ("cell_id", elevation_flat)},
     coords={
-        "x": x_unique.astype(np.float32),
-        "y": y_unique.astype(np.float32),
+        "cell_id": ("cell_id", cell_id_flat),
+        "x": ("cell_id", x_per_cell),
+        "y": ("cell_id", y_per_cell),
+        "longitude_UTM50N": ("cell_id", lon_per_cell),
+        "latitude_UTM50N": ("cell_id", lat_per_cell),
     },
 )
 
-# Once we have reprojected, resampled, and validated the elevation dataset
-# (with all invalid values handled), we save the final result as a NetCDF file.
-dataset_xy.to_netcdf(output_filename)
+# Once the elevation dataset has been reprojected, resampled,
+# and validated, it is exported to a NetCDF file. This format
+# is required by the VE model for spatial inputs.
+dataset_cell.to_netcdf(output_filename)
 
-print(f"✅ Saved resampled elevation ({res} m) to {output_filename}")
+print(f"✅ Saved VE-style elevation (cell_id structure) to {output_filename}")

--- a/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
+++ b/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
@@ -182,7 +182,6 @@ if np.isnan(dst_data).any():
     filled_data[mask] = dst_data[tuple(nearest_index[:, mask])]
     dst_data = filled_data
 
-# Reformat DEM to Virtual Ecosystem (VE) 1D grid structure
 # The original grid coordinates (cell_x, cell_y) represent projected
 # UTMcell-centre positions. To ensure consistency with VE inputs, these
 # coordinates are converted to distances relative to the grid origin

--- a/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
+++ b/analysis/abiotic/data_download/maliau_elevation_data_processing_script.py
@@ -23,8 +23,10 @@ description: |
     5. Handles invalid values:
          - Masks raster nodata values
          - Fills remaining NaNs using nearest-neighbour interpolation
-    6. Reformats the elevation dataset into VE-style (x, y, elevation) layout.
-    7. Saves the processed NetCDF output ready for VE abiotic model use.
+    6. Reformats the elevation data from a 2D spatial grid into the VE 1D grid
+       structure, where dimension is represented by a unique cell_id,
+       with corresponding coordinates stored as x and y variables.
+    7. Saves the processed NetCDF output ready for VE hydrology module use.
 
   The SRTM DEM used here was obtained from the Shuttle Radar Topography Mission
   and reprojected to UTM Zone 50N for the SAFE Project area (4°N 116°E to 5°N 117°E).
@@ -50,13 +52,13 @@ status: final
 
 input_files:
   - name: SRTM_UTM50N_processed.tif
-    path: data/sites/
+    path: data/primary/
     description: |
       30 m SRTM DEM for the SAFE Project region (4°N 116°E to 5°N 117°E), reprojected
       to UTM Zone 50N. The dataset is available via:
       https://zenodo.org/records/3490488
 
-  - name: maliau_site_definition.toml
+  - name: maliau_grid_definition_90m.toml
     path: data/sites/
     description: |
       Site definition file specifying the target VE grid for Maliau Basin.
@@ -64,7 +66,7 @@ input_files:
       in UTM Zone 50N (EPSG:32650).
 
 output_files:
-  - name: elevation_Maliau_2010_2020_UTM50N.nc
+  - name: elevation_maliau_2010_2020_90m.nc
     path: data/derived/abiotic/elevation_data/
     description: |
       Elevation dataset resampled to a 90 m grid in UTM Zone 50N. Invalid values
@@ -106,7 +108,7 @@ input_srtm = Path("../../../data/primary/SRTM_UTM50N_processed.tif")
 # interpolated elevation data to be used in the VE model
 output_dir = Path("../../../data/derived/abiotic/elevation_data")
 output_dir.mkdir(parents=True, exist_ok=True)
-output_filename = output_dir / "elevation_maliau_2010_2020_UTM50N.nc"
+output_filename = output_dir / "elevation_maliau_2010_2020_90m.nc"
 
 # Load the destination grid details
 with open("../../../sites/maliau_grid_definition_90m.toml", "rb") as f:


### PR DESCRIPTION
This update modifies the Maliau elevation preprocessing script so that the
output dataset follows the Virtual Ecosystem (VE) spatial data structure and
addresses the issue reported in “Input data is flipped when mapped on grid
#1054” #1054

Key changes include:

Replacing the 2D spatial dimensions (x, y) with a single cell_id
dimension consistent with VE grid structure.

Flattening the elevation grid using row-major ordering with a top-left
origin (cell_id = 0 at the top-left cell).

Explicitly controlling the orientation of the y-axis to prevent the grid
from being flipped when mapped to VE cells.

Storing per-cell spatial coordinates (x, y, and UTM coordinates) so
that each cell_id can be correctly mapped back to its spatial position.

These changes ensure that the elevation dataset aligns with the VE grid
layout and prevent the input data from being vertically flipped when mapped
onto the simulation grid.