### PR TITLE
180 remove downward shortwave radiation from plant input data

### DIFF
--- a/analysis/plant/csv_plant_input_data/csv_plant_input_data_Maliau_50x50.R
+++ b/analysis/plant/csv_plant_input_data/csv_plant_input_data_Maliau_50x50.R
@@ -211,7 +211,12 @@ write.csv(
 # Prepare plant_constants_Maliau_50x50
 
 # Start from subcanopy_parameters
-plant_constants_Maliau_50x50 <- subcanopy_parameters
+plant_constants_Maliau_50x50 <- subset(subcanopy_parameters,
+  select = -c(
+    subcanopy_vegetation_biomass,
+    subcanopy_seedbank_biomass
+  )
+)
 
 # Variables required:
 # subcanopy_extinction_coef OK

--- a/analysis/plant/csv_plant_input_data/csv_plant_input_data_Maliau_50x50_simplified.R
+++ b/analysis/plant/csv_plant_input_data/csv_plant_input_data_Maliau_50x50_simplified.R
@@ -218,7 +218,12 @@ write.csv(
 # Prepare plant_constants_Maliau_50x50
 
 # Start from subcanopy_parameters
-plant_constants_Maliau_50x50 <- subcanopy_parameters
+plant_constants_Maliau_50x50 <- subset(subcanopy_parameters,
+  select = -c(
+    subcanopy_vegetation_biomass,
+    subcanopy_seedbank_biomass
+  )
+)
 
 # Variables required:
 # subcanopy_extinction_coef OK

--- a/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50.R
+++ b/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50.R
@@ -89,53 +89,6 @@ n_pft <- length(unique(cohort_distribution$plant_cohorts_pft))
 print(unique(cohort_distribution$plant_cohorts_pft))
 pft_index <- unique(cohort_distribution$plant_cohorts_pft)
 
-# time_index
-# The time_index depends on the intended runtime of the simulation
-# For the Maliau site, use 11 years (2010-2020) with monthly intervals and
-# express:
-# -using days since origin (in this case 2010-01-01) OR
-# -converting these days since origin to actual dates
-
-# Approach suggested by David, following current implementation of time in VE
-generate_timestamps <- function(
-  start = "2010-01-01",
-  end = "2020-12-31",
-  interval_in_days = 30.4375
-) {
-  # Get the start and end as datetime objects and find the runtime as a difftime
-  start <- as.POSIXct(start)
-  end <- as.POSIXct(end)
-  interval <- as.difftime(interval_in_days, units = "days")
-  config_runtime <- (end - start)
-
-  # Check the difftimes use the same units
-  stopifnot(
-    attr(config_runtime, "units") == "days" &&
-      attr(interval, "units") == "days"
-  )
-
-  # Get the time sequence, which can extend the actual runtime to fit the last iteration
-  n_updates <- ceiling(unclass(config_runtime) / unclass(interval))
-  time_indices <- seq(0, n_updates - 1)
-  diffs <- interval * time_indices
-  interval_starts <- start + diffs
-
-  # Converts start datetimes to dates, which truncates to day
-  interval_starts <- as.Date(format(interval_starts, "%Y-%m-%d"))
-
-  return(list(interval_starts = interval_starts, time_indices = time_indices))
-}
-
-timestamps <- generate_timestamps()
-time_index <- timestamps$time_indices
-interval_starts <- timestamps$interval_starts
-
-# Define the time unit (do not use start of simulation as reference date, as this
-# gives -1 for the first index)
-time_unit <- "days since 2010-01-01"
-# RNetCDF::utinvcal.nc can convert POSIXct to the specified time unit
-time <- utinvcal.nc(time_unit, as.POSIXct(interval_starts))
-
 #####
 
 # Generate the data for the desired variables, taking the axes into account,
@@ -149,11 +102,6 @@ time <- utinvcal.nc(time_unit, as.POSIXct(interval_starts))
 # https://www.jstor.org/stable/2559870)
 plant_pft_propagules <-
   matrix(as.integer(1000), nrow = length(pft_index), ncol = length(cell_id_index))
-
-# downward_shortwave_radiation: matrix of cell_id by time_index (so 132 by 250)
-# Use fill value = 2040
-downward_shortwave_radiation <-
-  matrix(as.integer(2040), nrow = length(time_index), ncol = length(cell_id_index))
 
 # Load the subcanopy parameters
 subcanopy_parameters <- read.csv(
@@ -184,34 +132,22 @@ nc <-
 # Define dimensions
 dim.def.nc(nc, "cell_id", length(cell_id_index))
 dim.def.nc(nc, "pft", length(pft_index))
-dim.def.nc(nc, "time_index", length(time_index))
 
 # Define variables (integer = NC_UINT, numeric = NC_FLOAT, character = NC_STRING)
 # The arguments are: nc file name in R, data type, dimension names
 # Note that the order of dimensions is "flipped"
 var.def.nc(nc, "plant_pft_propagules", "NC_INT", c("pft", "cell_id"))
-var.def.nc(nc, "downward_shortwave_radiation", "NC_DOUBLE", c("time_index", "cell_id"))
 var.def.nc(nc, "subcanopy_vegetation_biomass", "NC_FLOAT", "cell_id")
 var.def.nc(nc, "subcanopy_seedbank_biomass", "NC_FLOAT", "cell_id")
-var.def.nc(nc, "time", "NC_DOUBLE", "time_index")
 var.def.nc(nc, "cell_id", "NC_INT", "cell_id")
 var.def.nc(nc, "pft", "NC_STRING", "pft")
-var.def.nc(nc, "time_index", "NC_INT", "time_index")
-
-# For time, also need to add the attributes so that the actual dates can be
-# calculated from days since reference date
-att.put.nc(nc, "time", "long_name", "NC_CHAR", "time")
-att.put.nc(nc, "time", "units", "NC_CHAR", time_unit)
 
 # Write the data to variables
 var.put.nc(nc, "plant_pft_propagules", plant_pft_propagules)
-var.put.nc(nc, "downward_shortwave_radiation", downward_shortwave_radiation)
 var.put.nc(nc, "subcanopy_vegetation_biomass", subcanopy_vegetation_biomass)
 var.put.nc(nc, "subcanopy_seedbank_biomass", subcanopy_seedbank_biomass)
-var.put.nc(nc, "time", time)
 var.put.nc(nc, "cell_id", cell_id_index)
 var.put.nc(nc, "pft", pft_index)
-var.put.nc(nc, "time_index", time_index)
 
 # Sync data to file and close.
 sync.nc(nc)
@@ -224,14 +160,11 @@ plant_input_data_Maliau_50x50 <-
 
 names(plant_input_data_Maliau_50x50$var)
 ncvar_get(plant_input_data_Maliau_50x50, "plant_pft_propagules")
-ncvar_get(plant_input_data_Maliau_50x50, "downward_shortwave_radiation")
 ncvar_get(plant_input_data_Maliau_50x50, "subcanopy_vegetation_biomass")
 ncvar_get(plant_input_data_Maliau_50x50, "subcanopy_seedbank_biomass")
-ncvar_get(plant_input_data_Maliau_50x50, "time")
 
 ncvar_get(plant_input_data_Maliau_50x50, "cell_id")
 ncvar_get(plant_input_data_Maliau_50x50, "pft")
-ncvar_get(plant_input_data_Maliau_50x50, "time_index")
 
 # Close
 nc_close(plant_input_data_Maliau_50x50)

--- a/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50_simplified.R
+++ b/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50_simplified.R
@@ -89,53 +89,6 @@ cell_id_index <- unique(cohort_distribution$plant_cohorts_cell_id)
 n_pft <- 2 # "overstory" and "understory"
 pft_index <- c("overstory", "understory")
 
-# time_index
-# The time_index depends on the intended runtime of the simulation
-# For the Maliau site, use 11 years (2010-2020) with monthly intervals and
-# express:
-# -using days since origin (in this case 2010-01-01) OR
-# -converting these days since origin to actual dates
-
-# Approach suggested by David, following current implementation of time in VE
-generate_timestamps <- function(
-  start = "2010-01-01",
-  end = "2020-12-31",
-  interval_in_days = 30.4375
-) {
-  # Get the start and end as datetime objects and find the runtime as a difftime
-  start <- as.POSIXct(start)
-  end <- as.POSIXct(end)
-  interval <- as.difftime(interval_in_days, units = "days")
-  config_runtime <- (end - start)
-
-  # Check the difftimes use the same units
-  stopifnot(
-    attr(config_runtime, "units") == "days" &&
-      attr(interval, "units") == "days"
-  )
-
-  # Get the time sequence, which can extend the actual runtime to fit the last iteration
-  n_updates <- ceiling(unclass(config_runtime) / unclass(interval))
-  time_indices <- seq(0, n_updates - 1)
-  diffs <- interval * time_indices
-  interval_starts <- start + diffs
-
-  # Converts start datetimes to dates, which truncates to day
-  interval_starts <- as.Date(format(interval_starts, "%Y-%m-%d"))
-
-  return(list(interval_starts = interval_starts, time_indices = time_indices))
-}
-
-timestamps <- generate_timestamps()
-time_index <- timestamps$time_indices
-interval_starts <- timestamps$interval_starts
-
-# Define the time unit (do not use start of simulation as reference date, as this
-# gives -1 for the first index)
-time_unit <- "days since 2010-01-01"
-# RNetCDF::utinvcal.nc can convert POSIXct to the specified time unit
-time <- utinvcal.nc(time_unit, as.POSIXct(interval_starts))
-
 #####
 
 # Generate the data for the desired variables, taking the axes into account,
@@ -149,11 +102,6 @@ time <- utinvcal.nc(time_unit, as.POSIXct(interval_starts))
 # https://www.jstor.org/stable/2559870)
 plant_pft_propagules <-
   matrix(as.integer(1000), nrow = length(pft_index), ncol = length(cell_id_index))
-
-# downward_shortwave_radiation: matrix of cell_id by time_index (so 132 by 250)
-# Use fill value = 2040
-downward_shortwave_radiation <-
-  matrix(as.integer(2040), nrow = length(time_index), ncol = length(cell_id_index))
 
 # Load the subcanopy parameters
 subcanopy_parameters <- read.csv(
@@ -184,34 +132,22 @@ nc <-
 # Define dimensions
 dim.def.nc(nc, "cell_id", length(cell_id_index))
 dim.def.nc(nc, "pft", length(pft_index))
-dim.def.nc(nc, "time_index", length(time_index))
 
 # Define variables (integer = NC_UINT, numeric = NC_FLOAT, character = NC_STRING)
 # The arguments are: nc file name in R, data type, dimension names
 # Note that the order of dimensions is "flipped"
 var.def.nc(nc, "plant_pft_propagules", "NC_INT", c("pft", "cell_id"))
-var.def.nc(nc, "downward_shortwave_radiation", "NC_DOUBLE", c("time_index", "cell_id"))
 var.def.nc(nc, "subcanopy_vegetation_biomass", "NC_FLOAT", "cell_id")
 var.def.nc(nc, "subcanopy_seedbank_biomass", "NC_FLOAT", "cell_id")
-var.def.nc(nc, "time", "NC_DOUBLE", "time_index")
 var.def.nc(nc, "cell_id", "NC_INT", "cell_id")
 var.def.nc(nc, "pft", "NC_STRING", "pft")
-var.def.nc(nc, "time_index", "NC_UINT", "time_index")
-
-# For time, also need to add the attributes so that the actual dates can be
-# calculated from days since reference date
-att.put.nc(nc, "time", "long_name", "NC_CHAR", "time")
-att.put.nc(nc, "time", "units", "NC_CHAR", time_unit)
 
 # Write the data to variables
 var.put.nc(nc, "plant_pft_propagules", plant_pft_propagules)
-var.put.nc(nc, "downward_shortwave_radiation", downward_shortwave_radiation)
 var.put.nc(nc, "subcanopy_vegetation_biomass", subcanopy_vegetation_biomass)
 var.put.nc(nc, "subcanopy_seedbank_biomass", subcanopy_seedbank_biomass)
-var.put.nc(nc, "time", time)
 var.put.nc(nc, "cell_id", cell_id_index)
 var.put.nc(nc, "pft", pft_index)
-var.put.nc(nc, "time_index", time_index)
 
 # Sync data to file and close.
 sync.nc(nc)
@@ -224,14 +160,11 @@ plant_input_data_Maliau_50x50 <-
 
 names(plant_input_data_Maliau_50x50$var)
 ncvar_get(plant_input_data_Maliau_50x50, "plant_pft_propagules")
-ncvar_get(plant_input_data_Maliau_50x50, "downward_shortwave_radiation")
 ncvar_get(plant_input_data_Maliau_50x50, "subcanopy_vegetation_biomass")
 ncvar_get(plant_input_data_Maliau_50x50, "subcanopy_seedbank_biomass")
-ncvar_get(plant_input_data_Maliau_50x50, "time")
 
 ncvar_get(plant_input_data_Maliau_50x50, "cell_id")
 ncvar_get(plant_input_data_Maliau_50x50, "pft")
-ncvar_get(plant_input_data_Maliau_50x50, "time_index")
 
 # Close
 nc_close(plant_input_data_Maliau_50x50)


### PR DESCRIPTION
Fixes #180 by removing shortwave radiation and its time dimension from the input data scripts and related data files.
Also removes subcanopy vegetation and seedbank biomass from the plant constants.