### PR TITLE
246 Scaled pft propagules to cell area used

### DIFF
--- a/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50.R
+++ b/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50.R
@@ -96,10 +96,14 @@ pft_index <- unique(cohort_distribution$plant_cohorts_pft)
 # analysis scripts
 
 # plant_pft_propagules: matrix of cell_id by pft (so 4 by 250)
-# Use fill value = 1000 using value reported in Metcalfe and Turner (1998;
+# Use fill value = 1000 m-2 using value reported in Metcalfe and Turner (1998;
 # https://www.jstor.org/stable/2559870)
+# Then scale this according to the cell area used (here 10000 m2)
+# Then divide this number by the amount of PFTs (assuming equal distribution)
 plant_pft_propagules <-
-  matrix(as.integer(1000), nrow = length(pft_index), ncol = length(cell_id_index))
+  matrix(as.integer(1000 * 10000 / 4),
+    nrow = length(pft_index), ncol = length(cell_id_index)
+  )
 
 # Load the subcanopy parameters
 subcanopy_parameters <- read.csv(

--- a/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50_simplified.R
+++ b/analysis/plant/netcdf_plant_input_data/netcdf_plant_input_data_Maliau_50x50_simplified.R
@@ -96,10 +96,14 @@ pft_index <- c("overstory", "understory")
 # analysis scripts
 
 # plant_pft_propagules: matrix of cell_id by pft (so 4 by 250)
-# Use fill value = 1000 using value reported in Metcalfe and Turner (1998;
+# Use fill value = 1000 m-2 using value reported in Metcalfe and Turner (1998;
 # https://www.jstor.org/stable/2559870)
+# Then scale this according to the cell area used (here 10000 m2)
+# Then divide this number by the amount of PFTs (assuming equal distribution)
 plant_pft_propagules <-
-  matrix(as.integer(1000), nrow = length(pft_index), ncol = length(cell_id_index))
+  matrix(as.integer(1000 * 10000 / 2),
+    nrow = length(pft_index), ncol = length(cell_id_index)
+  )
 
 # Load the subcanopy parameters
 subcanopy_parameters <- read.csv(


### PR DESCRIPTION
Multiplied seeds per m2 by the cell area used (10000 m2), assuming equal distribution across PFTs.

As the reference is originally from pioneer seeds, using 1000 per m2 might be an overestimation for the non-pioneer PFTs, but currently it's the best/only data we've got.