### PR TITLE
replace xy displacement with original UTM coords

### DIFF
--- a/analysis/litter/initialisation/maliau_litter_data.R
+++ b/analysis/litter/initialisation/maliau_litter_data.R
@@ -67,7 +67,8 @@ litter_meta <- parseTOML("data/scenarios/maliau/soil_litter_metadata.toml")
 
 # Maliau site metadata ----------------------------------------------------
 
-maliau <- parseTOML("data/derived/site/maliau_grid_definition_100m.toml")
+maliau <-
+  parseTOML("data/derived/site/maliau/maliau_grid_definition_100m.toml")
 
 # total number of grids
 n_sim <- with(maliau, cell_nx * cell_ny)
@@ -81,11 +82,6 @@ dat <-
   expand_grid(
     cell_x = maliau$cell_x_centres,
     cell_y = maliau$cell_y_centres
-  ) |>
-  # calculate displacements
-  mutate(
-    x = cell_x - min(cell_x),
-    y = cell_y - min(cell_y)
   )
 
 
@@ -377,16 +373,8 @@ var.def.nc(ncout, "y", "NC_FLOAT", "y")
 var.def.nc(ncout, "element", "NC_STRING", "element")
 att.put.nc(ncout, "x", "units", "NC_CHAR", "m")
 att.put.nc(ncout, "y", "units", "NC_CHAR", "m")
-var.put.nc(
-  ncout,
-  "x",
-  as.double(maliau$cell_x_centres - min(maliau$cell_x_centres))
-)
-var.put.nc(
-  ncout,
-  "y",
-  as.double(maliau$cell_y_centres - min(maliau$cell_y_centres))
-)
+var.put.nc(ncout, "x", as.double(maliau$cell_x_centres))
+var.put.nc(ncout, "y", as.double(maliau$cell_y_centres))
 var.put.nc(ncout, "element", c("C", "N", "P"))
 
 # define variables

--- a/analysis/litter/stock/model_aboveground_C.R
+++ b/analysis/litter/stock/model_aboveground_C.R
@@ -57,7 +57,6 @@ library(readxl)
 library(glmmTMB)
 
 
-
 # Data --------------------------------------------------------------------
 
 # Litter stock data by Riutta et al.

--- a/analysis/soil/initialisation/maliau_soil_data.R
+++ b/analysis/soil/initialisation/maliau_soil_data.R
@@ -106,13 +106,16 @@ source("analysis/soil/initialisation/model_safe.R")
 dat <-
   dat |>
   mutate(
-    elev = terra::extract(elev, pick("cell_x", "cell_y"))[,
+    elev = terra::extract(elev, pick("cell_x", "cell_y"))[
+      ,
       "SRTM_UTM50N_processed"
     ],
-    topo = terra::extract(topo, pick("cell_x", "cell_y"))[,
+    topo = terra::extract(topo, pick("cell_x", "cell_y"))[
+      ,
       "SRTM_UTM50N_TRI_Wilson2007"
     ],
-    hydro = terra::extract(hydro, pick("cell_x", "cell_y"))[,
+    hydro = terra::extract(hydro, pick("cell_x", "cell_y"))[
+      ,
       "SRTM_Log_Flow_Accum"
     ],
     # set acd to mean because there is no full data coverage

--- a/analysis/soil/initialisation/maliau_soil_data.R
+++ b/analysis/soil/initialisation/maliau_soil_data.R
@@ -78,7 +78,8 @@ soil_meta <- parseTOML("data/scenarios/maliau/soil_litter_metadata.toml")
 
 # Maliau site metadata ----------------------------------------------------
 
-maliau <- parseTOML("data/derived/site/maliau_grid_definition_100m.toml")
+maliau <-
+  parseTOML("data/derived/site/maliau/maliau_grid_definition_100m.toml")
 
 # total number of grids
 n_sim <- with(maliau, cell_nx * cell_ny)

--- a/analysis/soil/initialisation/maliau_soil_data.R
+++ b/analysis/soil/initialisation/maliau_soil_data.R
@@ -93,11 +93,6 @@ dat <-
   expand_grid(
     cell_x = maliau$cell_x_centres,
     cell_y = maliau$cell_y_centres
-  ) |>
-  # calculate displacements
-  mutate(
-    x = cell_x - min(cell_x),
-    y = cell_y - min(cell_y)
   )
 
 
@@ -111,16 +106,13 @@ source("analysis/soil/initialisation/model_safe.R")
 dat <-
   dat |>
   mutate(
-    elev = terra::extract(elev, pick("cell_x", "cell_y"))[
-      ,
+    elev = terra::extract(elev, pick("cell_x", "cell_y"))[,
       "SRTM_UTM50N_processed"
     ],
-    topo = terra::extract(topo, pick("cell_x", "cell_y"))[
-      ,
+    topo = terra::extract(topo, pick("cell_x", "cell_y"))[,
       "SRTM_UTM50N_TRI_Wilson2007"
     ],
-    hydro = terra::extract(hydro, pick("cell_x", "cell_y"))[
-      ,
+    hydro = terra::extract(hydro, pick("cell_x", "cell_y"))[,
       "SRTM_Log_Flow_Accum"
     ],
     # set acd to mean because there is no full data coverage
@@ -492,16 +484,8 @@ var.def.nc(ncout, "y", "NC_FLOAT", "y")
 var.def.nc(ncout, "element", "NC_STRING", "element")
 att.put.nc(ncout, "x", "units", "NC_CHAR", "m")
 att.put.nc(ncout, "y", "units", "NC_CHAR", "m")
-var.put.nc(
-  ncout,
-  "x",
-  as.double(maliau$cell_x_centres - min(maliau$cell_x_centres))
-)
-var.put.nc(
-  ncout,
-  "y",
-  as.double(maliau$cell_y_centres - min(maliau$cell_y_centres))
-)
+var.put.nc(ncout, "x", as.double(maliau$cell_x_centres))
+var.put.nc(ncout, "y", as.double(maliau$cell_y_centres))
 var.put.nc(ncout, "element", c("C", "N", "P"))
 
 # define variables

--- a/analysis/soil/initialisation/model_safe.R
+++ b/analysis/soil/initialisation/model_safe.R
@@ -108,7 +108,9 @@ elev <-
 
 # Topography
 topo <-
-  rast("data/primary/abiotic/SAFE_topographic_roughness/SRTM_UTM50N_TRI_Wilson2007.tif")
+  rast(
+    "data/primary/abiotic/SAFE_topographic_roughness/SRTM_UTM50N_TRI_Wilson2007.tif"
+  )
 
 # Climate
 # Not included now
@@ -136,10 +138,10 @@ maliau <-
 # fill in missing coordinates
 extra_locations <-
   tribble(
-    ~location, ~lat, ~lon,
-    "OG3_DW1", 4.733986, 116.970434,
-    "OG3_DW2", 4.7341235, 116.967075,
-    "OG3_DW3", 4.734606, 116.965199
+    ~location , ~lat      , ~lon       ,
+    "OG3_DW1" , 4.733986  , 116.970434 ,
+    "OG3_DW2" , 4.7341235 , 116.967075 ,
+    "OG3_DW3" , 4.734606  , 116.965199
   ) %>%
   st_as_sf(coords = c("lon", "lat"), crs = 4326)
 # tidy up location info

--- a/analysis/soil/initialisation/model_safe.R
+++ b/analysis/soil/initialisation/model_safe.R
@@ -138,10 +138,10 @@ maliau <-
 # fill in missing coordinates
 extra_locations <-
   tribble(
-    ~location , ~lat      , ~lon       ,
-    "OG3_DW1" , 4.733986  , 116.970434 ,
-    "OG3_DW2" , 4.7341235 , 116.967075 ,
-    "OG3_DW3" , 4.734606  , 116.965199
+    ~location, ~lat, ~lon,
+    "OG3_DW1", 4.733986, 116.970434,
+    "OG3_DW2", 4.7341235, 116.967075,
+    "OG3_DW3", 4.734606, 116.965199
   ) %>%
   st_as_sf(coords = c("lon", "lat"), crs = 4326)
 # tidy up location info

--- a/analysis/soil/initialisation/model_safe.R
+++ b/analysis/soil/initialisation/model_safe.R
@@ -132,7 +132,7 @@ evi <-
 
 # Location details
 maliau <-
-  parseTOML("data/derived/site/maliau_grid_definition_100m.toml")
+  parseTOML("data/derived/site/maliau/maliau_grid_definition_100m.toml")
 # fill in missing coordinates
 extra_locations <-
   tribble(

--- a/analysis/soil/nutrient_pools/carbon_microbial.R
+++ b/analysis/soil/nutrient_pools/carbon_microbial.R
@@ -43,7 +43,7 @@ library(RcppTOML)
 library(terra)
 
 # Maliau basin extent
-maliau <- parseTOML("data/derived/site/maliau_grid_definition_100m.toml")
+maliau <- parseTOML("data/derived/site/maliau/maliau_grid_definition_100m.toml")
 maliau_ext <- ext(maliau$bounds, xy = TRUE)
 
 # Microbial to soil carbon ratio map


### PR DESCRIPTION
This PR replaces xy displacements in the soil and litter input data with the original UTM coordinates for consistent plotting across modules.

@lelavathy, I have uploaded the new soil and litter nc files to the `maliau_1_dev` folder on Globus. Could you test run them? And if they works fine, could you approve this PR? Thanks.