### PR TITLE
add a single function to run VE in R

### DIFF
--- a/analysis/soil/sensitivity/input_data/ve_run.R
+++ b/analysis/soil/sensitivity/input_data/ve_run.R
@@ -1,0 +1,1 @@
+library(ve.utils)

--- a/analysis/soil/sensitivity/input_data/ve_run.R
+++ b/analysis/soil/sensitivity/input_data/ve_run.R
@@ -1,1 +1,0 @@
-library(ve.utils)

--- a/tools/R/ve_run.R
+++ b/tools/R/ve_run.R
@@ -1,0 +1,32 @@
+#' Run the Virtual Ecosystem in R
+#'
+#' @param args A concatenated string of arguments. For example,
+#'   \code{ve_run --install-example /usr/abc} can be replicated by calling
+#'   \code{ve_run_cli(c('--install-example', '/usr/abc/'))}
+#' @param venv Optional path to a virtual environment where ve_run is installed.
+#'
+#' @returns An integer indicating success (0) or failure (1). Output and logs
+#'   are saved to the paths specified in `args`
+#'
+#' @examples
+#'   config_path <- "data/scenarios/maliau/maliau_2/config"
+#'   out_path <- "data/scenarios/maliau/maliau_2/out"
+#'   args <- c(
+#'     config_path,
+#'     "--out",
+#'     out_path,
+#'     "--logfile",
+#'     paste0(out_path, "/logfile.log"),
+#'     "--config",
+#'     "core.debug.truncate_run_at_update=4"
+#'   )
+#'   ve_run(args)
+
+ve_run <- function(args, venv) {
+  # use virtual environment if specified
+  reticulate::use_virtualenv(venv)
+  # import the ve_run_cli function from VE
+  ve_run_cli <- reticulate::import("virtual_ecosystem.entry_points")$ve_run_cli
+  # run VE
+  ve_run_cli(args)
+}

--- a/tools/R/ve_run.R
+++ b/tools/R/ve_run.R
@@ -46,11 +46,15 @@
 #'   )
 #'   ve_run(args)
 
-ve_run <- function(args, venv) {
-  # use virtual environment if specified
-  reticulate::use_virtualenv(venv)
+ve_run <- function(args, venv = NULL) {
+  if (!is.null(venv)) {
+    # use virtual environment if specified
+    reticulate::use_virtualenv(venv)
+  }
+
   # import the ve_run_cli function from VE
   ve_run_cli <- reticulate::import("virtual_ecosystem.entry_points")$ve_run_cli
+
   # run VE
   ve_run_cli(args)
 }

--- a/tools/R/ve_run.R
+++ b/tools/R/ve_run.R
@@ -1,3 +1,27 @@
+#| ---
+#| title: Run the Virtual Ecosystem in R
+#|
+#| description: |
+#|     The function in this script imports ve_run_cli from virtual_ecosystem.entry_points
+#|     to run VE directly from R.
+#|
+#| virtual_ecosystem_module: All
+#|
+#| author: Hao Ran Lai
+#|
+#| status: final
+#|
+#| input_files:
+#|
+#| output_files:
+#|
+#| package_dependencies:
+#|     - reticulate (R)
+#|     - virtual_ecosystem (Python)
+#|
+#| usage_notes: See function documentation below.
+#| ---
+
 #' Run the Virtual Ecosystem in R
 #'
 #' @param args A concatenated string of arguments. For example,


### PR DESCRIPTION
This PR adds a single function `ve_run()` to run VE from R. It is simply an import from VE's `ve_run_cli`, and is part of the team's experimentation with calling VE directly from R and Python, so we can include `ve_run` in for-loops etc.

In the function's metadata, there is a section `@example` that applied it to the `maliau_2` scenario. Sadly it does not have a progress bar, which is in VE's `main.ve_run` but not `entry_point.ve_run_cli`, I think? To judge progress, I look at the file writing in the `out` folder.

Not that the latest dev version does not work with the example data for some reason. So if you want to test run it on example data, use the release version of VE.