### PR TITLE
322 explore commenting on html reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -555,3 +555,6 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+
+/.quarto/
+**/*.quarto_ipynb

--- a/analysis/soil/validation/conceptual_blocks.qmd
+++ b/analysis/soil/validation/conceptual_blocks.qmd
@@ -9,6 +9,8 @@ format:
     toc-location: left
     theme: sandstone
     embed-resources: true
+comments:
+  hypothesis: true
 ---
 
 # Preamble


### PR DESCRIPTION
This PR adds a commenting widget by Hypothesis to the html report, which has been shared on [Dropbox](https://www.dropbox.com/scl/fi/v3klnehzmt1k3bq56obtn/conceptual_blocks.html?rlkey=vgzka74geojbalp0cxz3njegu&dl=0). Since the validation meeting is over, I think we should just merge this minor change. Feel free to explore commenting with Hypothesis in the future. I am going to enable it every time I write a report in the future and keep an eye on how this feature fit into our routine (or not).