### PR TITLE
Ignore .ipynb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,9 @@ rsconnect/
 # Python noise
 __pycache__
 
-# notebook caching
+# Jupyter notebook
 .ipynb_checkpoints
+.ipynb
 
 # Mac .DS_store
 .DS_store


### PR DESCRIPTION
This PR adds .ipynb to gitignore to prevent accidental pushing.