### PR TITLE
ci: add weekly soil report draft workflow

### DIFF
--- a/.github/workflows/weekly_soil_report.yml
+++ b/.github/workflows/weekly_soil_report.yml
@@ -1,0 +1,79 @@
+name: Weekly soil report draft
+
+on:
+  schedule:
+    # Every Monday at 09:00 SGT/MYT (UTC+8 = 01:00 UTC)
+    - cron: "0 1 * * MON"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-issue-tracker
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "release"
+          use-public-rspm: true
+
+      - name: Install R packages
+        run: install.packages(c("gh", "dplyr", "purrr", "lubridate", "glue"))
+        shell: Rscript {0}
+
+      - name: Update "Waiting for" section in qmd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: Rscript .github/scripts/draft_waiting_for.R
+
+      - name: Commit and push to draft branch
+        run: |
+          # Always reset the draft branch so skipped weeks don't break automation
+          git fetch origin
+          if git ls-remote --exit-code --heads origin chore/weekly-soil-draft; then
+            git push origin --delete chore/weekly-soil-draft
+          fi
+
+          git checkout -b chore/weekly-soil-draft
+          git add analysis/soil/issue_tracker/gh_progress_report.qmd
+          git diff --cached --quiet && echo "No changes, skipping PR." && exit 0
+          git commit -m "chore: update waiting-for section [skip ci]"
+          git push origin chore/weekly-soil-draft
+
+      - name: Open PR against gh-issue-tracker
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          gh pr create \
+            --base gh-issue-tracker \
+            --head chore/weekly-soil-draft \
+            --title "chore: weekly soil report draft – ${DATE}" \
+            --body "This is an automated draft to remind you to update the weekly soil report.
+
+          ## What was updated
+          The **\"Required elements (Waiting for)\"** section in
+          \`analysis/soil/issue_tracker/gh_progress_report.qmd\` has been rewritten
+          based on your open PRs with pending reviewers as of ${DATE}.
+
+          ## What still needs your attention
+          Please manually update:
+          - [ ] **Latest description** — summarise what you worked on this week
+          - [ ] **Required elements** — review and edit the auto-generated bullets below if needed
+          - [ ] **Additional notes** — anything else worth noting
+
+          Once done, merge this PR to keep \`gh-issue-tracker\` up to date.
+
+          Finally, compile the Quarto report locally and move the compiled HTML to Dropbox."

--- a/.github/workflows/weekly_soil_report.yml
+++ b/.github/workflows/weekly_soil_report.yml
@@ -10,6 +10,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: weekly-soil-report-draft-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   draft:
     runs-on: ubuntu-latest
@@ -29,16 +33,23 @@ jobs:
           r-version: "release"
           use-public-rspm: true
 
-      - name: Install R packages
-        run: install.packages(c("gh", "dplyr", "purrr", "lubridate", "glue"))
-        shell: Rscript {0}
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::gh
+            any::dplyr
+            any::purrr
+            any::lubridate
+            any::glue
 
-      - name: Update "Waiting for" section in qmd
+      - name: Update "Waiting for" section in report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: Rscript .github/scripts/draft_waiting_for.R
 
       - name: Commit and push to draft branch
+        id: push_draft
         run: |
           # Always reset the draft branch so skipped weeks don't break automation
           git fetch origin
@@ -48,15 +59,36 @@ jobs:
 
           git checkout -b chore/weekly-soil-draft
           git add analysis/soil/issue_tracker/gh_progress_report.qmd
-          git diff --cached --quiet && echo "No changes, skipping PR." && exit 0
+
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes, skipping push and PR."
+            exit 0
+          fi
+
           git commit -m "chore: update waiting-for section [skip ci]"
           git push origin chore/weekly-soil-draft
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Open PR against gh-issue-tracker
+      - name: Open or update PR against gh-issue-tracker
+        if: steps.push_draft.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DATE=$(date +%Y-%m-%d)
+
+          EXISTING_PR_URL=$(gh pr list \
+            --base gh-issue-tracker \
+            --head chore/weekly-soil-draft \
+            --state open \
+            --json url \
+            --jq '.[0].url')
+
+          if [ -n "$EXISTING_PR_URL" ]; then
+            echo "Open PR already exists: $EXISTING_PR_URL"
+            exit 0
+          fi
+
           gh pr create \
             --base gh-issue-tracker \
             --head chore/weekly-soil-draft \


### PR DESCRIPTION
This PR adds a weekly automation to draft me a soil progress report, so I will be notified to review it, and then give @annarallings timely updates. I keep forgetting to do it, and would really like to offload this mentally to a bot. Specifically, it adds `.github/workflows/weekly_soil_report.yml` to `main` so the scheduled trigger runs reliably.

The workflow itself still checks out `gh-issue-tracker`, updates only `analysis/soil/issue_tracker/gh_progress_report.qmd`, and **opens a PR targeting only `gh-issue-tracker`** from a branch `chore/weekly-soil-draft`. I.e., after this PR is merged, all subsequent reminder PRs will only target the `gh-issue-tracker` branch, instead of `main`. So no reviews are required and I'll just (silently) work on the reporting branch. That means `main` only hosts the workflow definition; report updates remain isolated to `gh-issue-tracker`.

Hope this is fine by you! Thanks 🙏🏼 

Once this is merged, I will test run it with `workflow_dispatch`.
