### PR TITLE
Update soil layer depth terminology in derived variable calculations

### DIFF
--- a/tests/testthat/test-get_derived_variables.R
+++ b/tests/testthat/test-get_derived_variables.R
@@ -112,7 +112,7 @@ test_that("get_total_soil_c_per_mass converts volume to mass and get_total_soil_
     get_total_soil_c_per_area(config = config)
   # Extract conversion factors from config
   bulk_density_VE <- config$abiotic$constants$bulk_density_soil
-  soil_layer_depth <- config$core$constants$max_depth_of_microbial_activity
+  soil_layer_depth <- config$core$constants$microbial_simulation_depth
   # Verify unit conversions: mass = volume / bulk_density; area = volume * depth
   expect_equal(result_volume_basis / bulk_density_VE, result_mass_basis)
   expect_equal(result_volume_basis * soil_layer_depth, result_area_basis)
@@ -225,7 +225,7 @@ test_that("get_total_soil_n_per_mass converts volume to mass and get_total_soil_
     tidync::tidync(test_path("mock_data.nc")) |>
     get_total_soil_n_per_area(config = config)
   bulk_density_VE <- config$abiotic$constants$bulk_density_soil
-  soil_layer_depth <- config$core$constants$max_depth_of_microbial_activity
+  soil_layer_depth <- config$core$constants$microbial_simulation_depth
   expect_equal(result_volume_basis / bulk_density_VE, result_mass_basis)
   expect_equal(result_volume_basis * soil_layer_depth, result_area_basis)
 })
@@ -268,7 +268,7 @@ test_that("get_total_soil_p_per_mass converts volume to mass and get_total_soil_
     tidync::tidync(test_path("mock_data.nc")) |>
     get_total_soil_p_per_area(config = config)
   bulk_density_VE <- config$abiotic$constants$bulk_density_soil
-  soil_layer_depth <- config$core$constants$max_depth_of_microbial_activity
+  soil_layer_depth <- config$core$constants$microbial_simulation_depth
   expect_equal(result_volume_basis / bulk_density_VE, result_mass_basis)
   expect_equal(result_volume_basis * soil_layer_depth, result_area_basis)
 })

--- a/tools/R/get_derived_variables.R
+++ b/tools/R/get_derived_variables.R
@@ -109,7 +109,7 @@ convert_volume_to_mass_basis <- function(volume_basis_data, config) {
 #' @return Array of soil nutrient per area.
 
 convert_volume_to_area_basis <- function(volume_basis_data, config) {
-  soil_layer_depth <- config$core$constants$max_depth_of_microbial_activity
+  soil_layer_depth <- config$core$constants$microbial_simulation_depth
   volume_basis_data * soil_layer_depth
 }
 


### PR DESCRIPTION
This PR updates the R tools and tests to use the `microbial_simulation_depth` constant parameter instead of the deprecated `max_depth_of_microbial_activity` for soil layer depth calculations, matching https://github.com/ImperialCollegeLondon/virtual_ecosystem/pull/1688