### PR TITLE
Demo for reading/manipulating Zarr outputs in python

### DIFF
--- a/analysis/troubleshoot/zarr_test/demo.py
+++ b/analysis/troubleshoot/zarr_test/demo.py
@@ -1,0 +1,146 @@
+"""
+---
+title: Demo for working with output Zarr files in python
+
+description: |
+    This demo shows how to read and work with Zarr files
+    produced by the virtual ecosystem model. It demonstrates how to access the data,
+    log transform it, and save a slice of the data to a new NetCDF file for further
+    analysis.
+
+virtual_ecosystem_module: All
+
+author:
+  - name: Nick
+
+status: final
+
+input_files:
+  - name: model_data.zarr
+    path: analysis/troubleshoot/zarr_test/ve_example/out/
+    description: |
+      VE model output in Zarr format, containing inputs, init conditions, and outputs
+      for a single run of the model. This file is used as input for the demo to
+      demonstrate how to read and analyze Zarr files in Python.
+
+output_files:
+  - name: transpiration_slice_log.nc
+    path: analysis/troubleshoot/zarr_test/ve_example/out/
+    description: |
+      Log-transformed slice of the transpiration data saved as a NetCDF file.
+
+package_dependencies:
+  - xarray
+  - zarr
+  - numpy
+  - os
+
+usage_notes: |
+  This demo is to explore the Zarr file format and how to read and work with Zarr files
+  in Python. It is not intended to be a comprehensive analysis of the model outputs,
+  but rather a demonstration of how to access and manipulate the data in the Zarr file
+  format.
+
+  Make sure to have the dependencies for zarr input file for xarray IO backends.
+  Install Zarr package for dependencies: pip install zarr
+
+  To run the demo,
+
+  If you are using linux,
+  setup VE in the right environment and version using the bash
+  script: analysis/troubleshoot/zarr_test/setup_linux.sh.
+  Then run the demo script using the command in your terminal:
+  chmod +x analysis/troubleshoot/zarr_test/setup_linux.sh
+  ./analysis/troubleshoot/zarr_test/setup_linux.sh
+
+  If you are using windows,
+  setup VE in the right virtual environment and right version
+  using the bash script: analysis/troubleshoot/zarr_test/setup.sh
+  To run the bash script, run bash analysis/troubleshoot/zarr_test/setup.sh
+  in your terminal (I use Git Bash). This will also install the example
+  data and then run ve_run on it to obtain the new Zarr output files.
+
+  This will install the example data and then run ve_run on it to obtain
+  the new Zarr output files.
+---
+"""  # noqa: D400, D212, D205, D415
+
+import os
+
+import numpy as np
+import xarray
+
+# ============================================================
+# Open the DataTree from the Zarr file
+# ============================================================
+
+t = xarray.open_datatree(
+    "analysis/troubleshoot/zarr_test/ve_example/out/model_data.zarr"
+)
+
+# ============================================================
+# Inspect the DataTree structure
+# ============================================================
+
+# print the hierachy and inspect the top level groups
+print(t)
+# print output can be long given the large number of VE output variables
+
+# ============================================================
+# List inputs and outputs
+# ============================================================
+
+inputs = t["inputs"]
+inputs
+
+outputs = t["outputs"]
+outputs
+
+# ============================================================
+# Looking at single array and its dimensions and attributes
+# ============================================================
+
+# Access transpiration from outputs
+transpiration = outputs["transpiration"]
+
+# Check shape
+print("Shape:", transpiration.shape)
+
+# Check dimensions
+print("Dimensions:", transpiration.dims)
+
+# Check coordinates
+print("Coordinates:", transpiration.coords)
+
+# Check attributes (unit, description)
+print("Units:", transpiration.attrs["unit"])
+print("Description:", transpiration.attrs["description"])
+
+# ============================================================
+# Inspect a slice of the transpiration data so we can feed to conventional functions
+# ============================================================
+# Select time indices 1-3
+transpiration_slice = transpiration.sel(time_index=slice(1, 3))
+
+# Basic statistics
+print("Mean transpiration:", transpiration_slice.mean().values)
+print("Max transpiration: ", transpiration_slice.max().values)
+print("Min transpiration: ", transpiration_slice.min().values)
+
+# log transform
+transpiration_slice_log = transpiration_slice.copy()
+transpiration_slice_log.values = np.log(transpiration_slice_log.values)
+
+# create new path for saving the manipulated slice
+save_path = "analysis/troubleshoot/zarr_test/ve_example/out/transpiration_slice_log.nc"
+
+# remove pre-existing file if it exists
+if os.path.exists(save_path):
+    os.remove(save_path)
+
+# writes manipulated slice to a new netcdf file
+transpiration_slice_log.to_netcdf(save_path)
+
+# verify the new netcdf file was created and inspect its contents
+new_t = xarray.open_dataset(save_path)
+print(new_t)

--- a/analysis/troubleshoot/zarr_test/demo.py
+++ b/analysis/troubleshoot/zarr_test/demo.py
@@ -90,11 +90,13 @@ print(t)
 # List inputs and outputs
 # ============================================================
 
-inputs = t["inputs"]
-inputs
-
 outputs = t["outputs"]
-outputs
+print("Available output variables:")
+print(list(outputs.data_vars))
+
+inputs = t["inputs"]
+print("Available input variables:")
+print(list(inputs.data_vars))
 
 # ============================================================
 # Looking at single array and its dimensions and attributes

--- a/analysis/troubleshoot/zarr_test/setup_linux.sh
+++ b/analysis/troubleshoot/zarr_test/setup_linux.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# =============================================================================
+# setup_linux.sh
+#
+# PURPOSE: Set up a Python virtual environment, install the virtual_ecosystem
+#          package from a specific GitHub commit, and run an example simulation.
+#
+# PLATFORM: Linux (also compatible with macOS and WSL).
+#
+# USAGE: bash analysis/troubleshoot/zarr_test/setup_linux.sh
+#        Run this script from the folder where you want everything to live.
+# =============================================================================
+
+# cd into analysis/troubleshoot/zarr_test
+cd "$(dirname "$0")" || exit
+
+# --- 1. Create the Python virtual environment --------------------------------
+
+echo "Creating virtual environment: ve_zarr_PR1667 ..."
+python3 -m venv ve_zarr_PR1667
+# NOTE: On some systems Python 3 may be available as 'python' instead.
+#       If the line above fails, try:  python -m venv ve_zarr_PR1667
+
+
+# --- 2. Activate the virtual environment -------------------------------------
+# "Activating" makes the terminal use this environment's Python and pip.
+#
+# [LINUX / macOS / WSL] uses bin/activate
+# [WINDOWS - Git Bash]  would use Scripts/activate instead
+
+echo "Activating virtual environment ..."
+source ve_zarr_PR1667/bin/activate
+
+# Confirm which Python is now in use (optional sanity check).
+echo "Using Python at: $(which python3)"
+
+
+# --- 3. Upgrade pip ----------------------------------------------------------
+# Keeps the package installer itself up to date; avoids some install warnings.
+
+echo "Upgrading pip ..."
+python3 -m pip install --upgrade pip
+
+
+# --- 4. Install the virtual_ecosystem package from GitHub --------------------
+# This installs a specific commit (86dadb1) directly from GitHub.
+# No need to manually download anything.
+
+echo "Installing virtual_ecosystem from GitHub (commit 86dadb1) ..."
+pip install git+https://github.com/ImperialCollegeLondon/virtual_ecosystem.git@86dadb1
+
+
+# --- 5. Install the example data ---------------------------------------------
+# The 've_run --install_example' command downloads/copies example config files
+# into the folder 've_example/' in your current directory.
+# ENFORCED SKIP: if ve_example/ already exists, this step is skipped.
+# Re-running --install-example into an existing folder may overwrite files.
+
+if [ -d "ve_example" ]; then
+    echo "ve_example/ already exists — skipping example install to avoid overwriting files."
+else
+    echo "Installing VE example files into ./ve_example/ ..."
+    ve_run --install-example ./
+fi
+
+
+# --- 6. Create the output directory ------------------------------------------
+# The simulation writes results to ve_example/out/.
+# 'mkdir -p' creates the folder and any missing parent folders without
+# throwing an error if it already exists.
+
+echo "Creating output directory: ve_example/out ..."
+mkdir -p ve_example/out
+
+
+# --- 7. Run the simulation ---------------------------------------------------
+
+echo "Running virtual_ecosystem simulation ..."
+ve_run ve_example/config/data_config.toml \
+    ve_example/config/abiotic_config.toml \
+    ve_example/config/animal_config.toml \
+    ve_example/config/hydrology_config.toml \
+    ve_example/config/litter_config.toml \
+    ve_example/config/plant_config.toml \
+    ve_example/config/soil_config.toml \
+    --out ve_example/out \
+    --logfile ve_example/out/logfile.log


### PR DESCRIPTION
This PR demonstrates examining and manipulating VE output stored in Zarr format using xarray (with zarr dependencies installed) in python. In particular, it demonstrates the use of `xr.open_dataset()` to access zarr files - see  https://github.com/ImperialCollegeLondon/virtual_ecosystem/pull/1667#issuecomment-4845117216

I included a setup script for linux and macOS to setup virtual environment, install the dev VE version, install example data, and then run ve_run to get the new Zarr output files, following 'setup.sh'. The setup won't be effective when we switch to 'uv' #384 

Perhaps @lelavathy and @Baizurah could review this to see if it makes sense. Feel free to make any suggestions or additions.
