### PR TITLE
Upload refactored ERA5 climate input data preparation script

### DIFF
--- a/analysis/abiotic/era5_climate_data/maliau_climate_data_processing_script.py
+++ b/analysis/abiotic/era5_climate_data/maliau_climate_data_processing_script.py
@@ -126,9 +126,11 @@ references: |
 ---
 """  # noqa: D212, D205
 
-import importlib
 import sys
 from pathlib import Path
+
+from tools.python.abiotic import cdsapi_downloader as cds
+from tools.python.abiotic import climate_tools as ct
 
 # ============================================================
 # PROJECT ROOT
@@ -144,43 +146,6 @@ sys.path.insert(
     0,
     str(project_root),
 )
-
-# ============================================================
-# IMPORT CLIMATE DATA DOWNLOAD TOOLS
-# ============================================================
-# Import functions for downloading ERA5-Land monthly climate
-# variables and hourly 2 m air temperature from the Copernicus
-# Climate Data Store (CDS).
-
-cdsapi_downloader = importlib.import_module("tools.python.abiotic.cdsapi_downloader")
-cdsapi_era5_hourly_temperature_downloader = (
-    cdsapi_downloader.cdsapi_era5_hourly_temperature_downloader
-)
-cdsapi_era5_monthly_downloader = cdsapi_downloader.cdsapi_era5_monthly_downloader
-
-# ============================================================
-# IMPORT CLIMATE PROCESSING TOOLS
-# ============================================================
-# Import functions for processing, interpolating, and
-# formatting ERA5-Land climate data into a Virtual Ecosystem
-# climate forcing dataset.
-
-climate_tools = importlib.import_module("tools.python.abiotic.climate_tools")
-add_atmospheric_co2 = climate_tools.add_atmospheric_co2
-add_global_attributes = climate_tools.add_global_attributes
-add_mean_annual_temperature = climate_tools.add_mean_annual_temperature
-calculate_monthly_dtr = climate_tools.calculate_monthly_dtr
-calculate_relative_humidity = climate_tools.calculate_relative_humidity
-convert_units = climate_tools.convert_units
-create_ve_dataset = climate_tools.create_ve_dataset
-finalise_ve_dataset = climate_tools.finalise_ve_dataset
-get_target_grid = climate_tools.get_target_grid
-interpolate_dataset = climate_tools.interpolate_dataset
-interpolate_variable = climate_tools.interpolate_variable
-read_site_configuration = climate_tools.read_site_configuration
-save_dataset = climate_tools.save_dataset
-select_required_variables = climate_tools.select_required_variables
-
 
 # ============================================================
 # USER SETTINGS
@@ -239,7 +204,7 @@ grid_file = (
 # target grid and simulation period required for climate
 # data preparation for the selected scenario.
 
-scenario = read_site_configuration(
+scenario = ct.read_site_configuration(
     grid_file,
     scenario_name,
 )
@@ -254,7 +219,7 @@ run_length = int(timing["run_length"].split()[0])
 end_year = start_year + run_length - 1
 end_date = f"{end_year}-12-31"
 
-target_grid = get_target_grid(scenario)
+target_grid = ct.get_target_grid(scenario)
 
 years = list(range(start_year, end_year + 1))
 
@@ -311,14 +276,14 @@ output_file = derived_data_dir / f"era5_{scenario_name}_{start_year}_{end_year}.
 print("\nDownloading ERA5-Land climate data...")
 
 # Download monthly averaged ERA5-Land climate data.
-era5_ds = cdsapi_era5_monthly_downloader(
+era5_ds = cds.cdsapi_era5_monthly_downloader(
     years=years,
     bbox=bbox,
     outfile=monthly_file,
 )
 
 # Download hourly 2m air temperature ERA5-Land data.
-hourly_ds = cdsapi_era5_hourly_temperature_downloader(
+hourly_ds = cds.cdsapi_era5_hourly_temperature_downloader(
     start_date=start_date,
     end_date=end_date,
     bbox=bbox,
@@ -335,11 +300,11 @@ hourly_ds = cdsapi_era5_hourly_temperature_downloader(
 
 print("\nProcessing climate variables...")
 
-monthly_dtr = calculate_monthly_dtr(hourly_ds)
+monthly_dtr = ct.calculate_monthly_dtr(hourly_ds)
 
-era5_ds = convert_units(era5_ds)
-era5_ds = calculate_relative_humidity(era5_ds)
-era5_ds = select_required_variables(era5_ds)
+era5_ds = ct.convert_units(era5_ds)
+era5_ds = ct.calculate_relative_humidity(era5_ds)
+era5_ds = ct.select_required_variables(era5_ds)
 
 
 # ============================================================
@@ -365,12 +330,12 @@ era5_ds = select_required_variables(era5_ds)
 
 print("\nInterpolating climate variables...")
 
-interpolated = interpolate_dataset(
+interpolated = ct.interpolate_dataset(
     dataset=era5_ds,
     target_grid=target_grid,
 )
 
-interpolated["dtr"] = interpolate_variable(
+interpolated["dtr"] = ct.interpolate_variable(
     monthly_dtr,
     target_grid,
 )
@@ -383,7 +348,7 @@ interpolated["dtr"] = interpolate_variable(
 
 print("\nCreating climate forcing dataset...")
 
-climate_ds = create_ve_dataset(interpolated)
+climate_ds = ct.create_ve_dataset(interpolated)
 
 
 # ============================================================
@@ -394,8 +359,8 @@ climate_ds = create_ve_dataset(interpolated)
 
 print("\nAdding climate variables...")
 
-climate_ds = add_mean_annual_temperature(climate_ds)
-climate_ds = add_atmospheric_co2(climate_ds)
+climate_ds = ct.add_mean_annual_temperature(climate_ds)
+climate_ds = ct.add_atmospheric_co2(climate_ds)
 
 
 # ============================================================
@@ -406,8 +371,8 @@ climate_ds = add_atmospheric_co2(climate_ds)
 
 print("\nFinalising climate forcing dataset...")
 
-climate_ds = finalise_ve_dataset(climate_ds)
-climate_ds = add_global_attributes(
+climate_ds = ct.finalise_ve_dataset(climate_ds)
+climate_ds = ct.add_global_attributes(
     climate_ds,
     scenario_name,
 )
@@ -500,7 +465,7 @@ else:
 
 print("\nSaving climate forcing dataset...")
 
-save_dataset(
+ct.save_dataset(
     dataset=climate_ds,
     outfile=output_file,
 )

--- a/tools/python/abiotic/cdsapi_downloader.py
+++ b/tools/python/abiotic/cdsapi_downloader.py
@@ -259,13 +259,13 @@ def cdsapi_era5_monthly_downloader(
 
     Variables downloaded
     --------------------
-    - 2 m temperature
-    - 2 m dewpoint temperature
-    - surface pressure
-    - 10 m u wind component
-    - total precipitation
-    - surface solar radiation downward
-    - surface thermal radiation downward
+    - 2 m temperature (K)
+    - 2 m dewpoint temperature (K)
+    - surface pressure (Pa)
+    - 10 m u wind component(m s-1)
+    - total precipitation (m)
+    - surface solar radiation downward (Jm-2)
+    - surface thermal radiation downward (Jm-2)
 
     Parameters
     ----------
@@ -338,7 +338,7 @@ def cdsapi_era5_hourly_temperature_downloader(
     bbox,
     outfile,
 ):
-    """Download ERA5-Land hourly 2 m temperature.
+    """Download ERA5-Land hourly 2 m temperature (K).
 
     Hourly temperature is required to calculate the monthly mean
     diurnal temperature range.

--- a/tools/python/generate_test_config.py
+++ b/tools/python/generate_test_config.py
@@ -3,10 +3,11 @@
 title: Generate test configurations for the virtual ecosystem.
 
 description: |
-    This function writes the generated configuration to
-    ``mock_config_path`` and does not return the configuration object. It is
-    intended to generate a default-value template, not meant to be used with
-    ve_run.
+    This function writes a minimal TOML configuration to
+    ``mock_config_path``. It reproduces only the fields used by the R tests
+    (soil-CNP pool derivation) using default values from VE, so the tests
+    remain stable regardless of changes to ``virtual_ecosystem`` or
+    ``pyrealm`` internals.
 
 virtual_ecosystem_module: All
 
@@ -19,36 +20,51 @@ input_files:
 output_files:
 
 package_dependencies:
-  - virtual_ecosystem
+  - tomli-w
 
 usage_notes: See function documentation below.
 ---
 """  # noqa: D205, D212
 
-from virtual_ecosystem.core.config_builder import generate_configuration
+from pathlib import Path
+
+import tomli_w
 
 
-def generate_test_config(mock_config_path):
-    """Generate and export a test configuration as a TOML file.
+def generate_test_config(mock_config_path: str | Path) -> None:
+    """Write a minimal VE-compatible TOML config file for testing.
 
-    Parameters
-    ----------
-    mock_config_path : str or pathlib.Path
-        Path where the generated TOML configuration will be written.
+    Only the fields accessed by the R soil-CNP tests are included.
+    Values match Virtual Ecosystem defaults to keep test expectations stable.
 
-    Returns
-    -------
-    None
+    Args:
+        mock_config_path: Path where the TOML configuration will be written.
 
     """
-    models = {
-        "core": {},
-        "abiotic": {},
-        "hydrology": {},
-        "soil": {},
-        "plants": {},
-        "animal": {},
+    _MICROBIAL_GROUPS = [
+        "saprotrophic_fungi",
+        "ectomycorrhiza",
+        "arbuscular_mycorrhiza",
+        "bacteria",
+    ]
+
+    config: dict = {
+        "core": {
+            "constants": {
+                "microbial_simulation_depth": 0.25,
+            },
+        },
+        "abiotic": {
+            "constants": {
+                "bulk_density_soil": 1175.0,
+            },
+        },
+        "soil": {
+            "microbial_group_definition": [
+                {"name": name, "c_n_ratio": 5.2, "c_p_ratio": 16.0}
+                for name in _MICROBIAL_GROUPS
+            ],
+        },
     }
 
-    config = generate_configuration(models)
-    config.export_toml(mock_config_path)
+    Path(mock_config_path).write_bytes(tomli_w.dumps(config).encode())


### PR DESCRIPTION
## Summary

This PR refactors the ERA5 climate input preparation workflow into reusable modules while preserving the existing functionality.

## Changes

### New modules

- `tools/python/abiotic/cdsapi_downloader.py`
  - Downloads ERA5-Land monthly averaged datasets
  - Downloads ERA5-Land hourly 2 m temperature
  - Automatically extracts downloaded archives

- `tools/python/abiotic/climate_tools.py`
  - Processes downloaded ERA5-Land datasets
  - Calculates monthly mean diurnal temperature range (DTR)
  - Performs spatial interpolation to the Virtual Ecosystem grid
  - Converts variables into VE-compatible format
  - Generates the final climate dataset

### Driver script

- Added `analysis/abiotic/era5_climate_data/maliau_climate_data_processing_script.py`
  - Provides a complete workflow for downloading and processing ERA5 climate inputs.

### Processing improvements

- Corrected radiation conversion from J m⁻² to W m⁻² using the appropriate daily conversion factor.
- Added monthly mean diurnal temperature range derived from hourly ERA5-Land 2 m temperature.

## Testing
- Successfully generated the Maliau climate dataset using the refactored workflow.
Both the climate input datasets for maliau_1 and maliau_2 have been uploaded to Globus. Change log also updated.

Fixes #415 