### PR TITLE
Pin mkdocs-material version to 9.7.0

### DIFF
--- a/.github/workflows/gh_deploy.yml
+++ b/.github/workflows/gh_deploy.yml
@@ -24,5 +24,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==9.7.0
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
This pull request updates the deployment workflow to ensure a specific version of the `mkdocs-material` package is used during deployment. The pinned version is based on the first version that `mkdocs-material` went into [maintenance mode](https://github.com/squidfunk/mkdocs-material/releases#release-9.7.0).