### PR TITLE
Update Maliau input data change log to reflect enhanced soil microbial definitions

### DIFF
--- a/data/scenarios/maliau/maliau_1/change_log.txt
+++ b/data/scenarios/maliau/maliau_1/change_log.txt
@@ -31,7 +31,7 @@
     hourly 2 m air temperature.
 - References:
   - PR #414 to close Issue #415
-  - PR #415 to close Issue #416
+  - PR #417 to close Issue #416
 
 2026-07-10
 - Module: Litter

--- a/data/scenarios/maliau/maliau_1/change_log.txt
+++ b/data/scenarios/maliau/maliau_1/change_log.txt
@@ -1,18 +1,21 @@
 # Change log of maliau_1 scenario input data
 
 2026-07-23
-
-- Module: Core configuration
+- Module: All
 - Author: Baizurah Malik
 - Files changed:
-  - Configuration files in the `maliau_1/config` folder (Globus)
+  - All configuration files in the `maliau_1/config` folder (Globus)
 - Changes made:
-  - Replaced the previous scenario configuration files with the latest
-    configuration files generated using Virtual Ecosystem version 0.2.1.
+  - Replaced the previous scenario configuration files to be compatible with
+    Virtual Ecosystem version 0.2.1.
+  - soil.microbial_group_definition and soil.enzyme_class_definition have been
+    updated to use more realistic values that differentiate the guilds,
+    following the same values from the VE example data.
+- Notes:
   - Users should verify the file-path entries before running the scenario
     and add the plant output block where required.
 - References:
-  - Updating configurations for the new Zarr output format
+  - PR #1667 (virtual_ecosystem repo)
 
 2026-07-20
 - Module: Abiotic & Hydrology

--- a/data/scenarios/maliau/maliau_1/change_log.txt
+++ b/data/scenarios/maliau/maliau_1/change_log.txt
@@ -4,7 +4,8 @@
 - Module: All
 - Author: Baizurah Malik
 - Files changed:
-  - All configuration files in the `maliau_1/config` folder (Globus)
+  - All configuration files in the `data/scenarios/maliau/maliau_1/config`
+    folder (Globus)
 - Changes made:
   - Replaced the previous scenario configuration files to be compatible with
     Virtual Ecosystem version 0.2.1.
@@ -21,7 +22,7 @@
 - Module: Abiotic & Hydrology
 - Author: Lelavathy
 - Files changed:
-  - `era5_maliau_2010_2020_100m.nc` (Globus)
+  - `data/scenarios/maliau/maliau_1/data/era5_maliau_2010_2020_100m.nc` (Globus)
 - Changes made:
   - Corrected the conversion of `downward_shortwave_radiation` and
     `downward_longwave_radiation` from J m⁻² to W m⁻² using the correct

--- a/data/scenarios/maliau/maliau_1/change_log.txt
+++ b/data/scenarios/maliau/maliau_1/change_log.txt
@@ -36,6 +36,8 @@
 2026-07-10
 - Module: Litter
 - Author: Hao Ran Lai
+- Files changed:
+  - `data/scenarios/maliau/maliau_1/data/litter_maliau.nc`
 - Initial woody litter nutrients are now split by land use type rather than
   plot block ID
 - Aboveground litter carbon stock is now split by land use type
@@ -47,6 +49,8 @@
 2026-07-07
 - Module: Soil
 - Author: Hao Ran Lai
+- Files changed:
+  - `data/scenarios/maliau/maliau_1/data/soil_maliau.nc`
 - Almost all variables were updated. The changes should be slight, as most
   analysis modifications were minor; primarily to generalise them beyond Maliau.
   During this process, Hao Ran made several minor improvements.

--- a/data/scenarios/maliau/maliau_2/change_log.txt
+++ b/data/scenarios/maliau/maliau_2/change_log.txt
@@ -22,7 +22,7 @@
 - Module: Abiotic & Hydrology
 - Author: Lelavathy
 - Files changed:
-  - `data/scenarios/maliau/maliau_2/data/era5_maliau_2010_2020_100m.nc` (Globus)
+  - `data/scenarios/maliau/maliau_2/data/era5_maliau_10x10_2010_2020.nc` (Globus)
 - Changes made:
   - Corrected the conversion of `downward_shortwave_radiation` and
     `downward_longwave_radiation` from J m⁻² to W m⁻² using the correct

--- a/data/scenarios/maliau/maliau_2/change_log.txt
+++ b/data/scenarios/maliau/maliau_2/change_log.txt
@@ -31,7 +31,7 @@
     hourly 2 m air temperature.
 - References:
   - PR #414 to close Issue #415
-  - PR #415 to close Issue #416
+  - PR #417 to close Issue #416
 
 2026-07-10
 - Module: Litter

--- a/data/scenarios/maliau/maliau_2/change_log.txt
+++ b/data/scenarios/maliau/maliau_2/change_log.txt
@@ -4,7 +4,8 @@
 - Module: All
 - Author: Baizurah Malik
 - Files changed:
-  - All configuration files in the `maliau_2/config` folder (Globus)
+  - All configuration files in the `data/scenarios/maliau/maliau_2/config`
+    folder (Globus)
 - Changes made:
   - Replaced the previous scenario configuration files to be compatible with
     Virtual Ecosystem version 0.2.1.
@@ -21,7 +22,7 @@
 - Module: Abiotic & Hydrology
 - Author: Lelavathy
 - Files changed:
-  - `era5_maliau_10x10_2010_2020.nc` (Globus)
+  - `data/scenarios/maliau/maliau_2/data/era5_maliau_2010_2020_100m.nc` (Globus)
 - Changes made:
   - Corrected the conversion of `downward_shortwave_radiation` and
     `downward_longwave_radiation` from J m⁻² to W m⁻² using the correct

--- a/data/scenarios/maliau/maliau_2/change_log.txt
+++ b/data/scenarios/maliau/maliau_2/change_log.txt
@@ -1,17 +1,21 @@
 # Change log of maliau_2 scenario input data
 
 2026-07-23
-- Module: Core configuration
+- Module: All
 - Author: Baizurah Malik
 - Files changed:
-  - Configuration files in the `maliau_2/config` folder (Globus)
+  - All configuration files in the `maliau_2/config` folder (Globus)
 - Changes made:
-  - Replaced the previous scenario configuration files with the latest
-    configuration files generated using Virtual Ecosystem version 0.2.1.
+  - Replaced the previous scenario configuration files to be compatible with
+    Virtual Ecosystem version 0.2.1.
+  - soil.microbial_group_definition and soil.enzyme_class_definition have been
+    updated to use more realistic values that differentiate the guilds,
+    following the same values from the VE example data.
+- Notes:
   - Users should verify the file-path entries before running the scenario
     and add the plant output block where required.
 - References:
-  - Updating configurations for the new Zarr output format
+  - PR #1667 (virtual_ecosystem repo)
 
 2026-07-20
 - Module: Abiotic & Hydrology

--- a/data/scenarios/maliau/maliau_2/change_log.txt
+++ b/data/scenarios/maliau/maliau_2/change_log.txt
@@ -36,6 +36,8 @@
 2026-07-10
 - Module: Litter
 - Author: Hao Ran Lai
+- Files changed:
+  - `data/scenarios/maliau/maliau_2/data/litter_maliau.nc`
 - Initial woody litter nutrients are now split by land use type rather than
   plot block ID
 - Aboveground litter carbon stock is now split by land use type
@@ -47,6 +49,8 @@
 2026-07-07
 - Module: Soil
 - Author: Hao Ran Lai
+- Files changed:
+  - `data/scenarios/maliau/maliau_2/data/soil_maliau.nc`
 - Almost all variables were updated. The changes should be slight, as most
   analysis modifications were minor; primarily to generalise them beyond Maliau.
   During this process, Hao Ran made several minor improvements.


### PR DESCRIPTION
This PR updates the change logs for both the `maliau_1` and `maliau_2` scenario input data to add/polish previously missing details:
- Soil microbial and enzyme definitions have actually been changed in the VE example configs, which is ported over to our new set of configs. I did not made it to PR #429 before it's closed, but here it is 😄 
- Added changed files to the previous soil and litter change logs, following newer format started by @lelavathy
- Fixed a PR number in the abiotic change log
- Updated the paths of the changed files to use full relative paths, for clarity

@Baizurah and @lelavathy can I get you to take a look, as they edited your logs? Thanks!