### PR TITLE
Add temporal data to validation database

### DIFF
--- a/data/derived/soil/validation/config/sources.yaml
+++ b/data/derived/soil/validation/config/sources.yaml
@@ -230,6 +230,15 @@
       unit: ug cm^-3
       description: Plant available soil phosphorus content
   dedup_key: plot.code
+  temporal:
+    format: "%d/%m/%Y"
+    timezone: "Asia/Kuching"
+    same_for_all_rows:
+      start: 01/12/2011
+      end: 31/03/2014
+      precision: day
+      note:
+        Start and end dates specified in the Summary sheet of the original file.
 - doi: 10.5281/ZENODO.3247592
   decision: excluded
   reason: no_soil_data
@@ -248,6 +257,40 @@
     publisher: Zenodo
     url: https://zenodo.org/record/3247592
     keywords: soil CO2 flux, 24 hour cycle, partitioning
+  source_id: author_year
+  data_file: data/primary/soil/source_id/*.csv
+  skip_rows: 0
+  variables:
+    var_original_1:
+      var_canonical: var_ve_1
+      unit: unit
+      description: .na
+  dedup_key:
+    - sample_id
+    - date
+    - site_id
+  coordinates:
+    from_file: .na
+    match_data_column: .na
+    match_location_column: .na
+    latitude_column: .na
+    longitude_column: .na
+    same_for_all_rows:
+      latitude: .na
+      longitude: .na
+      note: .na
+  temporal:
+    date_column: .na
+    start_column: .na
+    end_column: .na
+    format: .na
+    timezone: .na
+    precision: .na
+    same_for_all_rows:
+      start: .na
+      end: .na
+      precision: .na
+      note: .na
 - doi: 10.5281/ZENODO.3251901
   decision: excluded
   reason: used_elsewhere

--- a/tools/R/R/valdb.R
+++ b/tools/R/R/valdb.R
@@ -359,6 +359,9 @@ build_validation_database <- function(
         # attach spatial coordinates while the data is still one row per
         # observation, and before `unite()` consumes the dedup key columns
         add_coordinates(src) |>
+        # likewise for temporal coordinates: the date column is often itself a
+        # dedup key, so this must run before `unite()`
+        add_temporal(src) |>
         # combine dedup keys into a single ID column
         tidyr::unite("ID", tidyr::all_of(src$dedup_key)) |>
         # pivot to long format because this is the easiest way to convert units
@@ -422,6 +425,12 @@ build_validation_database <- function(
       longitude,
       location_type,
       coordinate_source,
+      time_start,
+      time_end,
+      time_type,
+      time_precision,
+      time_source,
+      time_note,
       var_original,
       value_original = value,
       unit_original,
@@ -616,6 +625,415 @@ validate_coordinates <- function(dat, source_id) {
     )
   }
 
+  invisible(dat)
+}
+
+
+#' Attach temporal coordinates to a source dataset
+#'
+#' This is an unexported helper for [build_validation_database()]. It adds six
+#' columns to a dataset: \code{time_start}, \code{time_end}, \code{time_type},
+#' \code{time_precision}, \code{time_source} and \code{time_note}.
+#'
+#' Times are stored as a HALF-OPEN interval \code{[time_start, time_end)} in
+#' UTC, so that consecutive periods tile without overlapping. A point-in-time
+#' observation is widened to its precision granule: a date-only sample becomes
+#' a one-day interval rather than a zero-width one, because a zero-width
+#' half-open interval would match nothing under any filter.
+#'
+#' Note that \code{lubridate::\%within\%} is closed at BOTH ends, so it
+#' disagrees with the stored convention by one granule at \code{time_end}.
+#' Filter with \code{time_start <= t & t < time_end} instead.
+#'
+#' Unlike the spatial case there is no curation standard to fall back on: SAFE
+#' datasets are usually plot-level summaries carrying no per-row date, so the
+#' sampling period normally has to be read off the summary metadata and entered
+#' as \code{same_for_all_rows}. A source with no \code{temporal} block at all
+#' gets \code{NA} times and a \code{time_source} of \code{"missing"}.
+#'
+#' @param dat A dataset that is one row per observation, still carrying its raw
+#'   \code{dedup_key} columns.
+#' @param src One source entry from the source YAML metadata.
+#'
+#' @returns \code{dat} with the six temporal columns added. The row count is
+#'   ensured to be the same.
+
+add_temporal <- function(dat, src) {
+  spec <- drop_blanks(src$temporal)
+  n_before <- nrow(dat)
+
+  # UTC throughout, so that the build is reproducible regardless of the
+  # machine's locale. The source zone is only used to interpret the input.
+  tz_in <- spec$timezone %||% "UTC"
+  precision <- spec$precision %||% "day"
+
+  # Case 0: nothing configured at all. Note that `drop_blanks()` only strips
+  # blank scalars, so an unedited template still leaves an all-NA
+  # `same_for_all_rows` list behind; emptiness has to be judged after that
+  # nested block has itself been cleaned.
+  blanket <- drop_blanks(spec$same_for_all_rows)
+  temporal_top_settings <- purrr::discard_at(spec, "same_for_all_rows")
+  if (length(temporal_top_settings) == 0 && length(blanket) == 0) {
+    cli::cli_warn(
+      "No sampling time for {.val {src$source_id}}: add a {.field temporal}
+       block to the source YAML. If the dataset carry no per-row date, then
+       {.field same_for_all_rows} with the sampling period is usually what you
+       want. Currently {.val NA} times are assigned for {.val {src$source_id}}."
+    )
+    return(empty_temporal(dat))
+  }
+
+  # Case 1: one blanket sampling window for the whole dataset
+  if (length(blanket) > 0) {
+    if (is.null(blanket$start)) {
+      cli::cli_abort(
+        "{.field same_for_all_rows} in {.val {src$source_id}} needs at least a
+         {.field start} value. You are getting this because you specified
+         something in {.field same_for_all_rows} but left {.field start} blank."
+      )
+    }
+    precision <- blanket$precision %||% precision
+    start <- parse_time(blanket$start, spec$format, tz_in, src$source_id)
+    # an "open" end marks an ongoing or unbounded campaign
+    if (is.null(blanket$end) || identical(blanket$end, "open")) {
+      end <- lubridate::NA_POSIXct_
+    } else {
+      # the YAML end is written as the last INCLUSIVE granule, so widen it to
+      # get the exclusive bound we store
+      end <- widen_time(
+        parse_time(blanket$end, spec$format, tz_in, src$source_id),
+        precision,
+        tz_in
+      )
+    }
+    dat <- dplyr::mutate(
+      dat,
+      time_start = start,
+      time_end = end,
+      time_type = "whole dataset",
+      time_precision = precision,
+      time_source = "same_for_all_rows",
+      time_note = blanket$note %||% NA_character_
+    )
+    validate_temporal(dat, src$source_id)
+    return(dat)
+  }
+
+  # Case 2: per-row times read from the data itself
+  if (!is.null(spec$date_column)) {
+    if (!is.null(spec$start_column) || !is.null(spec$end_column)) {
+      cli::cli_abort(
+        "{.val {src$source_id}} sets both {.field date_column} and
+         {.field start_column}/{.field end_column} in its {.field temporal}
+         block. Use one or the other: {.field date_column} for point-in-time
+         observations, the pair for windows."
+      )
+    }
+    check_time_columns(dat, spec$date_column, src$source_id)
+    dat <- dplyr::mutate(
+      dat,
+      time_start = parse_time(
+        .data[[spec$date_column]],
+        spec$format,
+        tz_in,
+        src$source_id
+      ),
+      # widen the instant to its precision granule
+      time_end = widen_time(time_start, precision, tz_in),
+      time_type = "instant"
+    )
+  } else if (!is.null(spec$start_column) && !is.null(spec$end_column)) {
+    check_time_columns(
+      dat,
+      c(spec$start_column, spec$end_column),
+      src$source_id
+    )
+    dat <- dplyr::mutate(
+      dat,
+      time_start = parse_time(
+        .data[[spec$start_column]],
+        spec$format,
+        tz_in,
+        src$source_id
+      ),
+      # the source end is the last inclusive granule; store the exclusive bound
+      time_end = widen_time(
+        parse_time(
+          .data[[spec$end_column]],
+          spec$format,
+          tz_in,
+          src$source_id
+        ),
+        precision,
+        tz_in
+      ),
+      time_type = "interval"
+    )
+  } else {
+    cli::cli_abort(
+      "The {.field temporal} block of {.val {src$source_id}} supplies neither
+       {.field date_column}, nor both of {.field start_column} and
+       {.field end_column}, nor {.field same_for_all_rows}. Give one of these,
+       or delete the block entirely."
+    )
+  }
+
+  dat <-
+    dat |>
+    dplyr::mutate(
+      time_precision = precision,
+      # cover partial missingness within an otherwise valid date column
+      time_source = dplyr::if_else(
+        is.na(time_start),
+        "missing",
+        "data_column"
+      ),
+      time_note = NA_character_
+    )
+
+  if (nrow(dat) != n_before) {
+    cli::cli_abort(
+      "Attaching times changed the number of rows of {.val {src$source_id}}
+       from {n_before} to {nrow(dat)}."
+    )
+  }
+
+  validate_temporal(dat, src$source_id)
+
+  dat
+}
+
+
+#' Sanity-check the temporal coordinates of one source dataset
+#'
+#' An unexported helper for [add_temporal()]. Following the spatial
+#' convention, structurally impossible times are an error, because they
+#' usually mean the columns were swapped or the date format was misread.
+#' Missing times are only a warning, because many sources genuinely never
+#' record when they sampled.
+#'
+#' @param dat A dataset with the six temporal columns.
+#' @param source_id The source ID, used in messages.
+#'
+#' @returns \code{dat}, invisibly.
+
+validate_temporal <- function(dat, source_id) {
+  # an end before its start is the temporal analogue of swapped lat/lon
+  reversed <- dat |>
+    dplyr::filter(!is.na(time_start), !is.na(time_end), time_end < time_start)
+
+  if (nrow(reversed) > 0) {
+    cli::cli_abort(
+      c(
+        "{nrow(reversed)} row{?s} of {.val {source_id}} end before they
+         start.",
+        "i" = "Are the start and end columns swapped, or is the date
+               {.field format} being misread?"
+      )
+    )
+  }
+
+  # an implausible year almost always means a misparsed format, or an Excel
+  # serial number that survived the manual CSV conversion
+  out_of_range <- dat |>
+    dplyr::filter(dplyr::if_any(
+      c(time_start, time_end),
+      \(x) !is.na(x) & !dplyr::between(lubridate::year(x), 1900, 2100)
+    ))
+
+  if (nrow(out_of_range) > 0) {
+    cli::cli_abort(
+      c(
+        "{nrow(out_of_range)} row{?s} of {.val {source_id}} fall outside
+         1900-2100.",
+        "i" = "Is the {.field format} entry wrong, or did an Excel serial
+               date number survive the manual CSV conversion?"
+      )
+    )
+  }
+
+  n_missing <- sum(dat$time_source == "missing")
+  if (n_missing > 0) {
+    cli::cli_warn(
+      "{n_missing} of {nrow(dat)} row{?s} of {.val {source_id}} have no
+       sampling time."
+    )
+  }
+
+  invisible(dat)
+}
+
+
+#' Assign wholly missing temporal columns
+#'
+#' An unexported helper for [add_temporal()], used when a source configures no
+#' times at all. Kept separate so that the six columns always appear with the
+#' same names and types, which matters because the sources are row-bound into
+#' one database.
+#'
+#' @param dat A dataset.
+#'
+#' @returns \code{dat} with the six temporal columns added, all missing.
+
+empty_temporal <- function(dat) {
+  dplyr::mutate(
+    dat,
+    time_start = lubridate::NA_POSIXct_,
+    time_end = lubridate::NA_POSIXct_,
+    time_type = NA_character_,
+    time_precision = NA_character_,
+    time_source = "missing",
+    time_note = NA_character_
+  )
+}
+
+
+#' Parse a source date or datetime into UTC
+#'
+#' An unexported helper for [add_temporal()]. Everything is stored in UTC so
+#' that the build does not depend on the machine's locale; \code{tz_in} says
+#' how to interpret the source strings, which for SAFE field data is usually
+#' \code{"Asia/Kuching"} rather than UTC.
+#'
+#' @param x A character, Date or POSIXct vector from the source.
+#' @param format A strptime-style format, or \code{NULL} to guess.
+#' @param tz_in IANA time zone the source values are expressed in.
+#' @param source_id The source ID, used in messages.
+#'
+#' @returns A POSIXct vector in UTC.
+
+parse_time <- function(x, format = NULL, tz_in = "UTC", source_id = NULL) {
+  # a bare number is almost certainly an Excel serial date, which would parse
+  # into a nonsense year and be caught much later
+  if (is.numeric(x)) {
+    cli::cli_abort(
+      c(
+        "The date column of {.val {source_id}} is numeric.",
+        "i" = "This usually indicates Excel serial numbers were exported instead
+               of dates. Reformat the column as a date before converting the
+               sheet to CSV."
+      )
+    )
+  }
+
+  if (inherits(x, "POSIXct")) {
+    return(lubridate::with_tz(x, "UTC"))
+  }
+
+  # a bare Date carries no zone, so anchor it at midnight in the source zone
+  if (inherits(x, "Date")) {
+    return(lubridate::with_tz(
+      lubridate::force_tz(
+        as.POSIXct(format(x), tz = "UTC"),
+        tz_in
+      ),
+      "UTC"
+    ))
+  }
+
+  x <- as.character(x)
+  parsed <- if (is.null(format)) {
+    # Only unambiguous ISO-like strings are safe to guess at. Without this
+    # guard `ymd_hms(truncated = 3)` happily reads "14/03/2015" as the year
+    # 2014, which is silent corruption rather than an error.
+    non_iso <- x[!is.na(x) & x != "" & !grepl("^\\d{4}[-/]\\d{2}", x)]
+    if (length(non_iso) > 0) {
+      n_non_iso <- length(non_iso)
+      example <- non_iso[[1]]
+      cli::cli_abort(
+        c(
+          "{.val {source_id}} has {n_non_iso} date{?s} that {?is/are} not in
+           ISO order, e.g. {.val {example}}.",
+          "i" = "Set an explicit {.field format} in the {.field temporal}
+                 block, e.g. {.val %d/%m/%Y}. Guessing is refused here because
+                 {.val 03/04/2015} is ambiguous between March and April."
+        )
+      )
+    }
+    lubridate::ymd_hms(x, tz = tz_in, quiet = TRUE, truncated = 3)
+  } else {
+    as.POSIXct(x, format = format, tz = tz_in)
+  }
+
+  n_failed <- sum(is.na(parsed) & !is.na(x) & x != "")
+  if (n_failed > 0) {
+    cli::cli_abort(
+      c(
+        "{n_failed} date{?s} of {.val {source_id}} could not be parsed.",
+        "i" = "Set an explicit {.field format} in the {.field temporal} block,
+               e.g. {.val %d/%m/%Y}. Note that {.val 03/04/2015} is ambiguous
+               and cannot be guessed reliably."
+      )
+    )
+  }
+
+  lubridate::with_tz(parsed, "UTC")
+}
+
+
+#' Widen a time instant to the exclusive end of its precision granule
+#'
+#' An unexported helper for [add_temporal()]. Because intervals are stored
+#' half-open, an instant stored as a zero-width interval would match nothing.
+#' Widening a date-only value to the following midnight keeps
+#' \code{time_start <= t & t < time_end} meaningful while
+#' \code{time_precision} records that the underlying observation was a point.
+#'
+#' @param x A POSIXct vector.
+#' @param precision One of \code{"second"}, \code{"day"}, \code{"month"} or
+#'   \code{"year"}.
+#' @param tz_in IANA time zone whose calendar defines the granule. This must
+#'   be the zone the source dates were expressed in, not UTC: a Malaysian
+#'   midnight is 16:00 UTC the previous day, so flooring in UTC would widen
+#'   the value onto the wrong calendar day.
+#'
+#' @returns A POSIXct vector in UTC.
+
+widen_time <- function(x, precision, tz_in = "UTC") {
+  # `period` rather than `duration`, so that months and years stay calendrical
+  if (!precision %in% c("second", "day", "month", "year")) {
+    cli::cli_abort(
+      "Unknown {.field precision} {.val {precision}}. Use one of
+       {.val second}, {.val day}, {.val month} or {.val year}."
+    )
+  }
+  step <- lubridate::period(1, units = precision)
+  # do the calendar arithmetic in the source zone, then return to UTC storage
+  local <- lubridate::with_tz(x, tz_in)
+  # floor first, so that a mid-day timestamp with day precision still yields a
+  # clean granule boundary
+  lubridate::with_tz(
+    lubridate::floor_date(local, unit = precision) + step,
+    "UTC"
+  )
+}
+
+
+#' Check that configured time columns exist in the data
+#'
+#' An unexported helper for [add_temporal()]. Named columns that are absent
+#' are an error rather than a warning, because a typo in the YAML would
+#' otherwise silently produce a dataset with no times at all.
+#'
+#' @param dat A dataset.
+#' @param cols Column names named in the \code{temporal} block.
+#' @param source_id The source ID, used in messages.
+#'
+#' @returns \code{dat}, invisibly.
+
+check_time_columns <- function(dat, cols, source_id) {
+  missing_cols <- setdiff(cols, names(dat))
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(
+      c(
+        "The {.field temporal} block of {.val {source_id}} names
+         {.field {missing_cols}}, which {?is/are} not in the dataset.",
+        "i" = "Note that only the {.field dedup_key} and {.field variables}
+               columns are read from {.field data_file}, so a date column must
+               also be listed in {.field dedup_key} to pass."
+      )
+    )
+  }
   invisible(dat)
 }
 

--- a/tools/R/R/valdb.R
+++ b/tools/R/R/valdb.R
@@ -24,6 +24,7 @@
 #|     - arrow
 #|     - cli
 #|     - dplyr
+#|     - lubridate
 #|     - purrr
 #|     - rcrossref
 #|     - readr
@@ -229,6 +230,44 @@ add_schema <- function(
       same_for_all_rows = list(
         latitude = NA,
         longitude = NA,
+        note = NA
+      )
+    ),
+    # Temporal coordinates. Every entry below is OPTIONAL, exactly like the
+    # `coordinates` block above. Most SAFE datasets are plot-level summaries
+    # with no per-row date, so `same_for_all_rows` is usually the default (and
+    # only) entry to fill. Delete what you do not need, or delete the whole
+    # `temporal` block.
+    #
+    # Times are stored as a HALF-OPEN interval [time_start, time_end) in UTC.
+    # A point-in-time observation is widened to its `precision` granule, so a
+    # date-only sample spans one whole day.
+    temporal = list(
+      # Column in `data_file` holding a single date/time per row. Use this for
+      # point-in-time observations.
+      date_column = NA,
+      # Use these two INSTEAD of `date_column` when each row carries its own
+      # start and end, e.g. a deployment or incubation window.
+      start_column = NA,
+      end_column = NA,
+      # strptime-style format, e.g. "%d/%m/%Y". Leave blank to let the parser
+      # guess, which only works for unambiguous ISO-like strings.
+      format = NA,
+      # IANA time zone the source dates are expressed in.
+      # Default: "UTC". SAFE field data is usually "Asia/Kuching".
+      # TODO: possible to validate this against spatial coordinates?
+      timezone = NA,
+      # Granularity actually known: "second", "day", "month" or "year".
+      # Default: "day".
+      precision = NA,
+      # Use this INSTEAD of the entries above when the source gives only one
+      # sampling window for every row, e.g. a campaign period named in the
+      # paper but never recorded per sample. Set `end` to the string "open"
+      # for an ongoing or unbounded campaign.
+      same_for_all_rows = list(
+        start = NA,
+        end = NA,
+        precision = NA,
         note = NA
       )
     )

--- a/tools/R/tests/testthat/test-add_coordinates.R
+++ b/tools/R/tests/testthat/test-add_coordinates.R
@@ -1,0 +1,215 @@
+#| ---
+#| title: Tests for spatial coordinate handling in the validation database
+#|
+#| description: |
+#|     Unit tests for add_coordinates(), the helper that attaches spatial
+#|     coordinates to each source dataset in the validation database. Tests
+#|     cover the default SAFE convention (a locations.csv exported from the
+#|     Locations sheet), blanket coordinates that apply to a whole dataset,
+#|     non-default column names, and the guard rails: duplicated location
+#|     keys that would inflate the number of observations, coordinates
+#|     outside the valid decimal-degree range, ambiguous multi-column dedup
+#|     keys, and missing or unmatched locations.
+#|
+#| virtual_ecosystem_module: All
+#|
+#| author: Hao Ran Lai
+#|
+#| status: final
+#|
+#| input_files:
+#|
+#| output_files:
+#|
+#| source_files:
+#|
+#| package_dependencies:
+#|     - testthat
+#|     - withr
+#|     - dplyr
+#|     - readr
+#|     - tibble
+#|
+#| usage_notes: |
+#|     Run via: testthat::test_dir("tools/R/tests/testthat")
+#|     All fixtures are written to temporary directories and cleaned up
+#|     automatically by withr::local_tempdir().
+#| ---
+
+# A minimal stand-in for a SAFE `Locations` sheet exported to CSV.
+write_locations <- function(dir, ...) {
+  locations <- tibble::tibble(
+    `Location name` = c("plot_a", "plot_b", "plot_c"),
+    Latitude = c(4.71, 4.72, NA),
+    Longitude = c(117.61, 117.62, NA),
+    Type = "POINT"
+  )
+  locations <- dplyr::bind_rows(locations, ...)
+  readr::write_csv(locations, file.path(dir, "locations.csv"))
+  locations
+}
+
+# A source config pointing at `dir`, mimicking one entry of sources.yaml.
+make_source <- function(dir, ...) {
+  utils::modifyList(
+    list(
+      source_id = "test_2020",
+      data_file = file.path(dir, "data.csv"),
+      dedup_key = "location_name"
+    ),
+    list(...)
+  )
+}
+
+test_data <- function() {
+  tibble::tibble(
+    location_name = c("plot_a", "plot_b"),
+    soil_N = c(1, 2)
+  )
+}
+
+
+test_that("coordinates are looked up from the default locations.csv", {
+  dir <- withr::local_tempdir()
+  write_locations(dir)
+
+  out <- add_coordinates(test_data(), make_source(dir))
+
+  expect_equal(nrow(out), 2)
+  expect_equal(out$latitude, c(4.71, 4.72))
+  expect_equal(out$longitude, c(117.61, 117.62))
+  expect_equal(out$location_type, c("POINT", "POINT"))
+  expect_equal(out$coordinate_source, c("locations_file", "locations_file"))
+})
+
+
+test_that("locations without coordinates are flagged, not dropped", {
+  dir <- withr::local_tempdir()
+  write_locations(dir)
+  dat <- tibble::tibble(location_name = c("plot_a", "plot_c"), soil_N = 1:2)
+
+  expect_warning(
+    out <- add_coordinates(dat, make_source(dir)),
+    "1 of 2 rows"
+  )
+  expect_equal(nrow(out), 2)
+  expect_equal(out$coordinate_source, c("locations_file", "missing"))
+})
+
+
+test_that("a blanket coordinate is applied to every row", {
+  dir <- withr::local_tempdir()
+  source_dat <- make_source(
+    dir,
+    coordinates = list(
+      same_for_all_rows = list(latitude = 4.74, longitude = 116.97)
+    )
+  )
+
+  out <- add_coordinates(test_data(), source_dat)
+
+  expect_true(all(out$latitude == 4.74))
+  expect_true(all(out$longitude == 116.97))
+  expect_true(all(out$coordinate_source == "same_for_all_rows"))
+  expect_true(all(out$location_type == "whole dataset"))
+})
+
+
+test_that("template entries left as NA are treated as not supplied", {
+  dir <- withr::local_tempdir()
+  write_locations(dir)
+  # this is the shape `add_schema()` writes before a curator edits it
+  source_dat <- make_source(
+    dir,
+    coordinates = list(
+      from_file = NA,
+      match_data_column = NA,
+      same_for_all_rows = list(latitude = NA, longitude = NA, note = NA)
+    )
+  )
+
+  out <- add_coordinates(test_data(), source_dat)
+
+  expect_equal(out$coordinate_source, c("locations_file", "locations_file"))
+})
+
+
+test_that("non-default column names are honoured", {
+  dir <- withr::local_tempdir()
+  tibble::tibble(plot_code = "plot_a", lat_dd = 4.71, lon_dd = 117.61) |>
+    readr::write_csv(file.path(dir, "custom.csv"))
+
+  source_dat <- make_source(
+    dir,
+    coordinates = list(
+      from_file = file.path(dir, "custom.csv"),
+      match_location_column = "plot_code",
+      latitude_column = "lat_dd",
+      longitude_column = "lon_dd"
+    )
+  )
+
+  out <- add_coordinates(test_data()[1, ], source_dat)
+
+  expect_equal(out$latitude, 4.71)
+  # a locations file without a `Type` column still gets the column
+  expect_true(is.na(out$location_type))
+})
+
+
+test_that("a duplicated location key aborts rather than inflating rows", {
+  dir <- withr::local_tempdir()
+  write_locations(
+    dir,
+    tibble::tibble(
+      `Location name` = "plot_a",
+      Latitude = 4.99,
+      Longitude = 117.99,
+      Type = "POINT"
+    )
+  )
+
+  expect_error(
+    add_coordinates(test_data(), make_source(dir)),
+    "must match at most 1 row"
+  )
+})
+
+
+test_that("out-of-range coordinates abort", {
+  dir <- withr::local_tempdir()
+  locations <- write_locations(dir)
+  # a swapped latitude/longitude pair, or a projected coordinate system
+  locations$Latitude <- locations$Longitude
+  readr::write_csv(locations, file.path(dir, "locations.csv"))
+
+  expect_error(
+    add_coordinates(test_data(), make_source(dir)),
+    "outside the valid"
+  )
+})
+
+
+test_that("a multi-column dedup key must name the location column", {
+  dir <- withr::local_tempdir()
+  write_locations(dir)
+  source_dat <- make_source(dir, dedup_key = c("location_name", "date"))
+
+  expect_error(
+    add_coordinates(test_data(), source_dat),
+    "multi-column"
+  )
+})
+
+
+test_that("a missing locations file warns and yields missing coordinates", {
+  dir <- withr::local_tempdir()
+
+  expect_warning(
+    out <- add_coordinates(test_data(), make_source(dir)),
+    "cannot find"
+  )
+  expect_equal(nrow(out), 2)
+  expect_true(all(out$coordinate_source == "missing"))
+  expect_true(all(is.na(out$latitude)))
+})

--- a/tools/R/tests/testthat/test-add_temporal.R
+++ b/tools/R/tests/testthat/test-add_temporal.R
@@ -1,0 +1,448 @@
+#| ---
+#| title: Tests for temporal coordinate handling in the validation database
+#|
+#| description: |
+#|     Unit tests for add_temporal(), the helper that attaches sampling times
+#|     to each source dataset in the validation database. The emphasis is on
+#|     the two failure modes that are silent rather than loud: time-zone
+#|     handling, where flooring an instant in UTC rather than in the source
+#|     zone widens it onto the wrong calendar day, and ambiguous date formats,
+#|     where a day-first string such as "14/03/2015" is otherwise read as the
+#|     year 2014 without complaint. Also covered are the half-open interval
+#|     convention, blanket campaign windows, open-ended ranges, and the
+#|     remaining guard rails.
+#|
+#| virtual_ecosystem_module: All
+#|
+#| author: Hao Ran Lai
+#|
+#| status: final
+#|
+#| input_files:
+#|
+#| output_files:
+#|
+#| source_files:
+#|
+#| package_dependencies:
+#|     - testthat
+#|     - withr
+#|     - dplyr
+#|     - lubridate
+#|     - tibble
+#|
+#| usage_notes: |
+#|     Run via: testthat::test_dir("tools/R/tests/testthat")
+#|     Tests that touch time zones pin the session zone with
+#|     withr::local_timezone(), so that they pass regardless of the machine
+#|     they run on.
+#| ---
+
+# A source config mimicking one entry of sources.yaml.
+make_source <- function(...) {
+  utils::modifyList(
+    list(source_id = "test_2015", dedup_key = "location_name"),
+    list(...)
+  )
+}
+
+test_data <- function(dates = c("2015-03-14", "2015-04-02")) {
+  tibble::tibble(
+    location_name = c("plot_a", "plot_b"),
+    sampled = dates,
+    soil_N = c(1, 2)
+  )
+}
+
+
+# Time zones ---------------------------------------------------------------
+
+test_that("a date-only value spans a full day in its own time zone", {
+  # the bug this guards against: local midnight in Asia/Kuching is 16:00 UTC
+  # the previous day, so flooring in UTC yields an 8-hour interval sitting on
+  # the wrong calendar day
+  withr::local_timezone("UTC")
+
+  out <- add_temporal(
+    test_data(),
+    make_source(
+      temporal = list(
+        date_column = "sampled",
+        timezone = "Asia/Kuching",
+        precision = "day"
+      )
+    )
+  )
+
+  expect_equal(
+    as.numeric(difftime(out$time_end, out$time_start, units = "hours")),
+    c(24, 24)
+  )
+  # the interval must start at local midnight on the stated date
+  local_start <- lubridate::with_tz(out$time_start, "Asia/Kuching")
+  expect_equal(
+    format(local_start, "%Y-%m-%d %H:%M"),
+    c(
+      "2015-03-14 00:00",
+      "2015-04-02 00:00"
+    )
+  )
+})
+
+
+test_that("times are stored in UTC regardless of the session time zone", {
+  # the build must not depend on the machine's locale
+  run_in <- function(tz) {
+    withr::local_timezone(tz)
+    add_temporal(
+      test_data("2015-03-14"[c(1, 1)]),
+      make_source(
+        temporal = list(
+          date_column = "sampled",
+          timezone = "Asia/Kuching"
+        )
+      )
+    )$time_start
+  }
+
+  expect_equal(run_in("UTC"), run_in("America/New_York"))
+  expect_equal(attr(run_in("America/New_York"), "tzone"), "UTC")
+})
+
+
+test_that("widening respects calendar days rather than fixed 24-hour spans", {
+  # 8 March 2015 is a spring-forward day in America/New_York, so the local day
+  # is only 23 hours long. Adding a fixed duration would overshoot midnight.
+  withr::local_timezone("UTC")
+
+  out <- add_temporal(
+    test_data("2015-03-08"[c(1, 1)]),
+    make_source(
+      temporal = list(
+        date_column = "sampled",
+        timezone = "America/New_York",
+        precision = "day"
+      )
+    )
+  )
+
+  expect_equal(
+    as.numeric(difftime(out$time_end[1], out$time_start[1], units = "hours")),
+    23
+  )
+  expect_equal(
+    format(lubridate::with_tz(out$time_end[1], "America/New_York"), "%H:%M"),
+    "00:00"
+  )
+})
+
+
+test_that("a mid-day timestamp still widens to a clean granule boundary", {
+  withr::local_timezone("UTC")
+
+  out <- add_temporal(
+    test_data("2015-03-14 08:30:00"[c(1, 1)]),
+    make_source(temporal = list(date_column = "sampled", precision = "day"))
+  )
+
+  expect_equal(format(out$time_start[1], "%Y-%m-%d %H:%M"), "2015-03-14 08:30")
+  expect_equal(format(out$time_end[1], "%Y-%m-%d %H:%M"), "2015-03-15 00:00")
+})
+
+
+# Ambiguous formats --------------------------------------------------------
+
+test_that("a non-ISO date without a declared format aborts", {
+  # left to guess, lubridate reads "14/03/2015" as the year 2014, which is
+  # silent corruption rather than an error
+  expect_error(
+    add_temporal(
+      test_data(c("14/03/2015", "02/04/2015")),
+      make_source(temporal = list(date_column = "sampled"))
+    ),
+    "ISO"
+  )
+})
+
+
+test_that("a declared format resolves an otherwise ambiguous date", {
+  withr::local_timezone("UTC")
+
+  day_first <- add_temporal(
+    test_data(c("03/04/2015", "03/04/2015")),
+    make_source(temporal = list(date_column = "sampled", format = "%d/%m/%Y"))
+  )
+  month_first <- add_temporal(
+    test_data(c("03/04/2015", "03/04/2015")),
+    make_source(temporal = list(date_column = "sampled", format = "%m/%d/%Y"))
+  )
+
+  expect_equal(lubridate::month(day_first$time_start[1]), 4)
+  expect_equal(lubridate::month(month_first$time_start[1]), 3)
+})
+
+
+test_that("ISO dates are still parsed without a declared format", {
+  withr::local_timezone("UTC")
+
+  out <- add_temporal(
+    test_data(),
+    make_source(temporal = list(date_column = "sampled"))
+  )
+
+  expect_equal(
+    format(out$time_start, "%Y-%m-%d"),
+    c("2015-03-14", "2015-04-02")
+  )
+  expect_equal(out$time_source, c("data_column", "data_column"))
+})
+
+
+test_that("a wrong declared format aborts rather than yielding NA times", {
+  expect_error(
+    add_temporal(
+      test_data(c("14/03/2015", "02/04/2015")),
+      make_source(
+        temporal = list(
+          date_column = "sampled",
+          format = "%Y-%m-%d"
+        )
+      )
+    ),
+    "parsed"
+  )
+})
+
+
+test_that("a numeric date column is caught as an Excel serial number", {
+  dat <- test_data()
+  dat$sampled <- c(42430, 42431)
+
+  expect_error(
+    add_temporal(dat, make_source(temporal = list(date_column = "sampled"))),
+    "numeric"
+  )
+})
+
+
+test_that("an implausible year aborts", {
+  # a two-digit year misread as the first century
+  expect_error(
+    add_temporal(
+      test_data(c("0015-03-14", "0015-04-02")),
+      make_source(temporal = list(date_column = "sampled"))
+    ),
+    "1900"
+  )
+})
+
+
+# Intervals and blanket windows --------------------------------------------
+
+test_that("a blanket campaign window is applied to every row", {
+  withr::local_timezone("UTC")
+
+  out <- add_temporal(
+    test_data(),
+    make_source(
+      temporal = list(
+        same_for_all_rows = list(
+          start = "2011-01-01",
+          end = "2014-12-01",
+          precision = "month",
+          note = "Paper states sampling ran 2011-2014"
+        )
+      )
+    )
+  )
+
+  expect_true(all(out$time_source == "same_for_all_rows"))
+  expect_true(all(out$time_type == "whole dataset"))
+  # the YAML end is the last inclusive granule, stored as an exclusive bound
+  expect_equal(format(out$time_end[1], "%Y-%m-%d"), "2015-01-01")
+  expect_true(all(out$time_note == "Paper states sampling ran 2011-2014"))
+})
+
+
+test_that("a per-row start/end pair is stored half-open", {
+  withr::local_timezone("UTC")
+
+  dat <- tibble::tibble(s = "2015-03-01", e = "2015-03-05")
+  out <- add_temporal(
+    dat,
+    make_source(
+      temporal = list(
+        start_column = "s",
+        end_column = "e",
+        precision = "day"
+      )
+    )
+  )
+
+  expect_equal(out$time_type, "interval")
+  expect_equal(format(out$time_end, "%Y-%m-%d"), "2015-03-06")
+  # the inclusive final day is inside the interval, the next day is not
+  expect_true(as.POSIXct("2015-03-05 23:00", tz = "UTC") < out$time_end)
+  expect_false(as.POSIXct("2015-03-06 00:00", tz = "UTC") < out$time_end)
+})
+
+
+test_that("an open-ended campaign leaves the end missing", {
+  out <- add_temporal(
+    test_data(),
+    make_source(
+      temporal = list(
+        same_for_all_rows = list(
+          start = "2011-01-01",
+          end = "open"
+        )
+      )
+    )
+  )
+
+  expect_true(all(is.na(out$time_end)))
+  expect_true(all(!is.na(out$time_start)))
+  expect_true(all(out$time_source == "same_for_all_rows"))
+})
+
+
+# Guard rails --------------------------------------------------------------
+
+test_that("a source with no temporal block warns and yields missing times", {
+  # this is the state of every currently configured source
+  expect_warning(
+    out <- add_temporal(test_data(), make_source()),
+    "No sampling time"
+  )
+
+  expect_equal(nrow(out), 2)
+  expect_true(all(is.na(out$time_start)))
+  expect_true(all(out$time_source == "missing"))
+  # the columns must still exist, and with the right types, because sources
+  # are row-bound into one database
+  expect_s3_class(out$time_start, "POSIXct")
+  expect_type(out$time_type, "character")
+})
+
+
+test_that("template entries left as NA are treated as not supplied", {
+  # this is the shape `add_schema()` writes before a curator edits it
+  source_dat <- make_source(
+    temporal = list(
+      date_column = NA,
+      start_column = NA,
+      end_column = NA,
+      format = NA,
+      timezone = NA,
+      precision = NA,
+      same_for_all_rows = list(start = NA, end = NA, precision = NA, note = NA)
+    )
+  )
+
+  expect_warning(
+    out <- add_temporal(test_data(), source_dat),
+    "No sampling time"
+  )
+  expect_true(all(out$time_source == "missing"))
+})
+
+
+test_that("an end before its start aborts", {
+  expect_error(
+    add_temporal(
+      tibble::tibble(s = "2015-03-05", e = "2015-03-01"),
+      make_source(temporal = list(start_column = "s", end_column = "e"))
+    ),
+    "start"
+  )
+})
+
+
+test_that("a mistyped column name aborts", {
+  expect_error(
+    add_temporal(
+      test_data(),
+      make_source(temporal = list(date_column = "date"))
+    ),
+    "not in the dataset"
+  )
+})
+
+
+test_that("mixing date_column with a start/end pair aborts", {
+  expect_error(
+    add_temporal(
+      test_data(),
+      make_source(
+        temporal = list(
+          date_column = "sampled",
+          start_column = "sampled",
+          end_column = "sampled"
+        )
+      )
+    ),
+    "sets both"
+  )
+})
+
+
+test_that("a blanket window without a start aborts", {
+  expect_error(
+    add_temporal(
+      test_data(),
+      make_source(
+        temporal = list(
+          same_for_all_rows = list(note = "sometime in the 2010s")
+        )
+      )
+    ),
+    "needs at least"
+  )
+})
+
+
+test_that("an unknown precision aborts", {
+  expect_error(
+    add_temporal(
+      test_data(),
+      make_source(
+        temporal = list(
+          date_column = "sampled",
+          precision = "fortnight"
+        )
+      )
+    ),
+    "precision"
+  )
+})
+
+
+test_that("partially missing dates are flagged, not dropped", {
+  expect_warning(
+    out <- add_temporal(
+      test_data(c("2015-03-14", NA)),
+      make_source(temporal = list(date_column = "sampled"))
+    ),
+    "1 of 2 rows"
+  )
+
+  expect_equal(nrow(out), 2)
+  expect_equal(out$time_source, c("data_column", "missing"))
+})
+
+
+test_that("the row count is never changed", {
+  dat <- test_data()
+
+  expect_equal(
+    nrow(add_temporal(
+      dat,
+      make_source(
+        temporal = list(
+          date_column = "sampled"
+        )
+      )
+    )),
+    nrow(dat)
+  )
+})


### PR DESCRIPTION
This PR is an incremental work that adds functions and unit tests to include temporal information to each validation dataset in the WIP pipeline.