### PR TITLE
Add change logs that were accidentally removed

### DIFF
--- a/data/scenarios/maliau/maliau_1/change_log.txt
+++ b/data/scenarios/maliau/maliau_1/change_log.txt
@@ -21,6 +21,31 @@
     proxies or published allometric relationships are used and documented in
     the associated input-data records.
 
+2026-08-07
+- Module: Soil, Litter
+- Author: Hao Ran Lai
+- Files changed:
+  - data/scenarios/maliau/maliau_1/data/soil_maliau.nc
+- Changes made:
+  - Fixed a missing conversion of [%] to [kg/kg], causing total soil carbon and
+    nitrogen to take on erroreously high values
+- References:
+  - PR #492 addressing Issue #471
+
+2026-07-31
+- Module: Soil, Litter
+- Author: Hao Ran Lai
+- Files changed:
+  - data/scenarios/maliau/maliau_1/data/litter_maliau.nc
+  - data/scenarios/maliau/maliau_1/data/soil_maliau.nc
+- Changes made:
+  - Fixed a missing transpose in the converter function
+    tools/R/R/convert_df_to_nc.R; all soil and litter input variables should
+    now be in the right dimensions. Notably, stoichiometric ratios should be
+    much more sensible.
+- References:
+  - PR #464 addressing Issue #455
+
 2026-07-23
 - Module: All
 - Author: Baizurah Malik

--- a/data/scenarios/maliau/maliau_2/change_log.txt
+++ b/data/scenarios/maliau/maliau_2/change_log.txt
@@ -21,6 +21,31 @@
     proxies or published allometric relationships are used and documented in
     the associated input-data records.
 
+2026-08-07
+- Module: Soil, Litter
+- Author: Hao Ran Lai
+- Files changed:
+  - data/scenarios/maliau/maliau_2/data/soil_maliau.nc
+- Changes made:
+  - Fixed a missing conversion of [%] to [kg/kg], causing total soil carbon and
+    nitrogen to take on erroreously high values
+- References:
+  - PR #492 addressing Issue #471
+
+2026-07-31
+- Module: Soil, Litter
+- Author: Hao Ran Lai
+- Files changed:
+  - data/scenarios/maliau/maliau_2/data/litter_maliau.nc
+  - data/scenarios/maliau/maliau_2/data/soil_maliau.nc
+- Changes made:
+  - Fixed a missing transpose in the converter function
+    tools/R/R/convert_df_to_nc.R; all soil and litter input variables should
+    now be in the right dimensions. Notably, stoichiometric ratios should be
+    much more sensible.
+- References:
+  - PR #464 addressing Issue #455
+
 2026-07-23
 - Module: All
 - Author: Baizurah Malik


### PR DESCRIPTION
@Baizurah can you take a look at this PR, which adds back two change logs per scenarios that seemed to be [accidentally deleted](https://github.com/ImperialCollegeLondon/ve_data_science/pull/495/changes) from your latest merge? I think you might have accidentally rejected incoming changes during a merge. Thanks.