### PR TITLE
Validation: screen more soil and litter datasets

### DIFF
--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-10044772.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-10044772.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-10044772
+doi: 10.5281/zenodo.10044772
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Soil variables are PCA axes and EM fungi is tree data (Quadrat level proportion
+    of basal area contributed by EcM trees).
+  screened_at: '2026-08-18T07:59:31Z'
+metadata:
+  title: 'Dataset and Code Accompanying the Study by Medina-Vega et al. in Nature
+    Ecology & Evolution: Tropical Tree Ectomycorrhiza Are Distributed Independently
+    of Soil Nutrients'
+  authors:
+  - Medina-Vega, José A.
+  - Zuleta, Daniel
+  - Aguilar, Salomón
+  - Alonso, Alfonso
+  - Bissiengou, Pulchérie
+  - Brockelman, Warren Y.
+  - Bunyavejchewin, Sarayudh
+  - Burslem, David F.R.P.
+  - Castaño, Nicolás
+  - Chave, Jérôme
+  - Dalling, James W.
+  - de Oliveira, Alexandre A.
+  - Duque, Álvaro
+  - Ediriweera, Sisira
+  - Ewango, Corneille E.N.
+  - Filip, Jonah
+  - Hubbell, Stephen P.
+  - Itoh, Akira
+  - Kiratiprayoon, Somboon
+  - Lum, Shawn K.Y.
+  - Makana, Jean-Remy
+  - Memiaghe, Hervé
+  - Mitre, David
+  - Mohamad, Mohizah Bt.
+  - Nathalang, Anuttara
+  - Nilus, Reuben
+  - Nkongolo, Nsalambi V.
+  - Novotny, Vojtech
+  - O'Brien, Michael J.
+  - Pérez, Rolando
+  - Pongpattananurak, Nantachai
+  - Reynolds, Glen
+  - Russo, Sabrina E.
+  - Tan, Sylvester
+  - Thompson, Jill
+  - Uriarte, María
+  - Valencia, Renato
+  - Vicentini, Alberto
+  - Yao, Tze Leong
+  - Zimmerman, Jess K.
+  - Davies, Stuart J.
+  year: 2023
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.10044772
+  keywords: ~
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:58:17Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-10701332.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-10701332.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-10701332
+doi: 10.5281/zenodo.10701332
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Soil keyword describe sampling method.
+  screened_at: '2026-08-18T08:07:57Z'
+metadata:
+  title: Growth and Survival of gap and understorey plots across Danum Valley 2004
+    - 2017
+  authors:
+  - O'Brien, Michael
+  - Philipson, Christopher
+  year: 2024
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.10701332
+  keywords: ~
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:07:38Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198302.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198302.yaml
@@ -1,0 +1,26 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198302
+doi: 10.5281/zenodo.1198302
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter keyword describe 'leaf litter ants'.
+  screened_at: '2026-08-18T07:20:53Z'
+metadata:
+  title: The Role Of Competition In Structuring Ant Community Composition Across A
+    Tropical Forest Disturbance Gradient
+  authors:
+  - Gray, Ross
+  - Gill, Richard
+  - Ewers, Robert
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198302
+  keywords:
+  - ant
+  - community composition
+  - competition
+  - body size
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:20:31Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198474.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198474.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198474
+doi: 10.5281/zenodo.1198474
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Leaf litter recorded as presence/absence only.
+  screened_at: '2026-08-18T07:18:27Z'
+metadata:
+  title: Otter Qpcr Data At Safe
+  authors: Layfield, Harry
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198474
+  keywords:
+  - Otter
+  - Temperature
+  - pH
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:18:06Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198557.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198557.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198557
+doi: 10.5281/zenodo.1198557
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Contains leaf litter mass only, insufficient to be derived to aboveground
+    litter pool. Also contains hydrology data.
+  screened_at: '2026-08-17T23:56:17Z'
+metadata:
+  title: A Preliminary Study Of The Allochthonous Inputs Into Tropical Streams Across
+    A Land Use Gradient In Sabah, Malaysia
+  authors: Cassell, Christopher
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198557
+  keywords:
+  - leaf litter
+  - aquatic
+  - biomass
+  provider: doi_content_search
+  retrieved_at: '2026-08-17T23:55:12Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198560.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198560.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198560
+doi: 10.5281/zenodo.1198560
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Deadwood density measured from semi-random samples, hard to extrapolate to
+    deadwood stock per area.
+  screened_at: '2026-08-18T07:28:42Z'
+metadata:
+  title: Deadwood Carbon Stocks Under Logging And Fragmentation Impacts
+  authors: Pfeifer, Marion
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198560
+  keywords:
+  - wood density
+  - coarse wood
+  - decomposition
+  - wood decay
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:27:37Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198564.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198564.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198564
+doi: 10.5281/zenodo.1198564
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Contains litter depth, topsoil depth, infiltration rate, categorical soil
+    organic matter (SOM), bulk density and porosity. But these are not validation
+    targets.
+  screened_at: '2026-08-18T07:03:25Z'
+metadata:
+  title: Land use effect on earthworms
+  authors: Rao, Sri
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198564
+  keywords:
+  - Earthworms
+  - Soil pits
+  - Soil structure
+  - Below ground biodiversity
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:01:30Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198576.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198576.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198576
+doi: 10.5281/zenodo.1198576
+screening:
+  decision: defer
+  reason: needs_second_opinion
+  notes: Deadwood stock are raw volumetric measurements that need to be converted
+    to mass basis. This requires an extra layer of processing script outside of the
+    validation pipeline. Also need to check with Rob Ewers if this is a duplicate
+    of Terhi Riutta's datasets.
+  screened_at: '2026-08-18T07:27:21Z'
+metadata:
+  title: Deadwood Stocks And Dynamics
+  authors:
+  - Ewers, Rob
+  - Pfeifer, Marion
+  - Turner, Ed
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198576
+  keywords:
+  - coarse woody debris
+  - decomposition status
+  - tree mortality
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:24:44Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198580.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198580.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198580
+doi: 10.5281/zenodo.1198580
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Contains leaf litter depth but not a validation target (or hard to convert
+    to carbon-mass per area).
+  screened_at: '2026-08-18T07:11:27Z'
+metadata:
+  title: Quantifying Predation Pressure Along A Gradient Of Land Use Intensity
+  authors: Boyle, Michael
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198580
+  keywords:
+  - predation
+  - mealworm
+  - trophic effects
+  - species interactions
+  - ecosystem process
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:10:04Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198586.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1198586.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1198586
+doi: 10.5281/zenodo.1198586
+screening:
+  decision: exclude
+  reason: duplicate_source
+  notes: Litter weights used in aboveground litter pools analysis.
+  screened_at: '2026-08-17T23:35:00Z'
+metadata:
+  title: Leaf Litter Fall
+  authors: Ewers, Rob
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1198586
+  keywords:
+  - litterfall
+  - primary productivity
+  - fruit mass
+  - flower mass
+  - seed mass
+  - leaf mass
+  provider: doi_content_search
+  retrieved_at: '2026-08-17T23:33:53Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1237729.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1237729.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1237729
+doi: 10.5281/zenodo.1237729
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter keyword describes field method about ant bait.
+  screened_at: '2026-08-17T23:57:22Z'
+metadata:
+  title: How does forest conversion and fragmentation affect ant communities and the
+    ecosystem processes that they mediate?
+  authors:
+  - Fayle, Tom
+  - Ewers, Robert
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1237729
+  keywords:
+  - ant
+  - scavenging
+  - community composition
+  provider: doi_content_search
+  retrieved_at: '2026-08-17T23:56:32Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1303010.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1303010.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1303010
+doi: 10.5281/zenodo.1303010
+screening:
+  decision: exclude
+  reason: insufficient_metadata
+  notes: Contains leaf litter mass only, insufficient to derive to aboveground litter
+    pools.
+  screened_at: '2026-08-17T23:53:25Z'
+metadata:
+  title: Leaf Litter Amphibian Communities
+  authors: Faruk, Aisyah
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1303010
+  keywords:
+  - frog
+  - amphibian
+  - community composition
+  - tadpole
+  provider: doi_content_search
+  retrieved_at: '2026-08-17T23:52:55Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1303017.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1303017.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1303017
+doi: 10.5281/zenodo.1303017
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter keyword describes litter trap methods to measure herbivory.
+  screened_at: '2026-08-18T07:05:44Z'
+metadata:
+  title: Evaluating Changing Patterns Of Herbivory As A Result Of Habitat Change
+  authors:
+  - Metcalfe, Dan
+  - Turner, E. C.
+  - Nilus, Reuben
+  - Ewers, R. M.
+  year: 2018
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1303017
+  keywords: herbivory
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:03:36Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-14213661.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-14213661.yaml
@@ -1,0 +1,37 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-14213661
+doi: 10.5281/zenodo.14213661
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Soil keyword describes sampling method.
+  screened_at: '2026-08-18T08:07:29Z'
+metadata:
+  title: SBE Seedling Matrix Plot Dataset
+  authors:
+  - O'Brien, Michael
+  - Burslem, David
+  - Jackson, Eleanor
+  - Jackson, Toby
+  - Jucker, Tommaso
+  - Reynolds, Glen
+  - Robert, Rolando
+  - Hector, Andy
+  year: 2024
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.14213661
+  keywords:
+  - demography
+  - dipterocarp
+  - forest regeneration
+  - tropical
+  - rainforest
+  - Sabah
+  - Malaysia
+  - Southeast Asia
+  - tree census
+  - biodiversity
+  - Sabah Biodiversity Experiment
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:06:19Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1478525.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-1478525.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-1478525
+doi: 10.5281/zenodo.1478525
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter recorded as cover on stream bed. Not useful.
+  screened_at: '2026-08-18T07:19:26Z'
+metadata:
+  title: All Fish catch data at the SAFE project 2011-2019
+  authors:
+  - Heon, Sui
+  - Wilkinson, Clare
+  - Bignet, Victoria
+  - Fikri, Arman Hadi
+  - Yeo, Darren
+  - Tan, Heok Hui
+  - Ewers, Robert M.
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/1478525
+  keywords:
+  - Freshwater fish
+  - land use change
+  - biodiversity
+  - oil palm
+  - logged forest
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:18:54Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-15368680.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-15368680.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-15368680
+doi: 10.5281/zenodo.15368680
+screening:
+  decision: defer
+  reason: outside_module_scope
+  notes: Decomposition keyword is about Small Mammal Carrion Depletion Rates.
+  screened_at: '2026-08-18T08:10:49Z'
+metadata:
+  title: Small Mammal Carrion Depletion Rates in Tropical Landscapes (2023-2024)
+  authors:
+  - Heon, Sui P.
+  - Bernard, Henry
+  - Ewers, Robert M
+  year: 2025
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.15368680
+  keywords:
+  - Small mammals
+  - Scavengers
+  - Necromass
+  - Carrion decomposition
+  - Old-growth
+  - Oil palm
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:08:46Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-15368703.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-15368703.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-15368703
+doi: 10.5281/zenodo.15368703
+screening:
+  decision: defer
+  reason: outside_module_scope
+  notes: Decomposition keyword describes Scavenger Observations on Small Mammal Carrion.
+    Might be useful for population density.
+  screened_at: '2026-08-18T08:11:34Z'
+metadata:
+  title: Scavenger Observations on Small Mammal Carrion in Tropical Landscapes of
+    Borneo (2023–2024)
+  authors:
+  - Heon, Sui Peng
+  - Bernard, Henry
+  - Ewers, Robert M.
+  year: 2025
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.15368703
+  keywords:
+  - Scavengers
+  - Land-use change
+  - Decomposition
+  - Carrion
+  - Tropical forests
+  - Small mammals
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:10:57Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-16005735.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-16005735.yaml
@@ -1,0 +1,26 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-16005735
+doi: 10.5281/zenodo.16005735
+screening:
+  decision: proceed
+  reason: relevant_validation_data
+  notes:
+    Contains ammonium, nitrate and phosphorus concentrations. Data embargoed but
+    Hao Ran has obtained permission.
+  screened_at: "2026-08-18T07:57:56Z"
+metadata:
+  title: Danum Valley 50-Ha Plot Soil Nutrient Data
+  authors: Burslem, David F.R.P.
+  year: 2025
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.16005735
+  keywords:
+    - soil pH
+    - soil nutrient
+    - 50-Ha plot
+    - Danum Valley
+    - Sabah
+    - Malaysia
+  provider: doi_content_search
+  retrieved_at: "2026-08-18T07:56:44Z"

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-16250654.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-16250654.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-16250654
+doi: 10.5281/zenodo.16250654
+screening:
+  decision: defer
+  reason: outside_module_scope
+  notes: Decomposition keyword is about the decay of a single mammal.
+  screened_at: '2026-08-18T08:12:26Z'
+metadata:
+  title: A single observation of an Orangutan carcass decomposition
+  authors:
+  - Heon, Sui P.
+  - Bernard, Henry
+  - Ewers, Robert M
+  year: 2025
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.16250654
+  keywords:
+  - Bornean Orangutan
+  - Scavengers
+  - Carrion Ecology
+  - Old-growth forest
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:12:10Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-17189186.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-17189186.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-17189186
+doi: 10.5281/zenodo.17189186
+screening:
+  decision: defer
+  reason: outside_module_scope
+  notes: Contains soil volumetric water content, leaf nutrient and physiological traits.
+  screened_at: '2026-08-18T08:06:10Z'
+metadata:
+  title: Traits from reciprocal transplanted seedlings of 6 species of Dipterocarpaceae
+  authors:
+  - Carle, Hannah
+  - Godoong, Elia
+  - Meir, Patrick
+  - O'Brien, Michael
+  year: 2025
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.17189186
+  keywords:
+  - dipterocarp
+  - functional trait
+  - hierarchical models
+  - intraspecific variation
+  - ontogeny
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:05:12Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-17458532.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-17458532.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-17458532
+doi: 10.5281/zenodo.17458532
+screening:
+  decision: exclude
+  reason: duplicate_source
+  notes: Soil nutrients very likely originated from the 50-Ha plot data (10.5281/zenodo.16005735),
+    which will be added to the validation database.
+  screened_at: '2026-08-18T08:04:59Z'
+metadata:
+  title: Data and code for Crown Exposure Regulates Aboveground Wood Productivity
+    Responses to Soil Fertility in Lowland Tropical Forests
+  authors:
+  - Medina-Vega, José
+  - Duque, Alvaro
+  - Zuleta, Daniel
+  - Castaño, Nicolas
+  - Valencia, Renato
+  - Aguilar, Salomón
+  - Mitre, David
+  - Pérez, Rolando
+  - Lum, Shawn K.Y.
+  - Burslem, David
+  - O'Brien, Michael
+  - Reynolds, Glen
+  - Bunyavejchewin, Sarayudh
+  - Pongpattananurak, Nantachai
+  - Phumsathan, Sangsan
+  - Ewango, Corneille
+  - Makana, Jean-Remy
+  - Itoh, Akira
+  - Mohamad, Mohizah Bt.
+  - Tan, Sylvester
+  - Thompson, Jill
+  - Uriarte, Maria
+  - Zimmerman, Jess K.
+  - Oliveira, Alexandre
+  - de Andrade, Ana C. S.
+  - da Silva, João Batista
+  - Vicentini, Alberto
+  - Brockelman, Warrren
+  - Nathalang, Anuttara
+  - Yao, Tze Leong
+  - Ediriweera, Sisira
+  - Novotny, Vojtech
+  - Weiblen, George
+  - Davies, Stuart
+  year: 2025
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/doi/10.5281/zenodo.17458532
+  keywords:
+  - AWP
+  - Fertility
+  - Plant-soil feedbacks
+  - Productivity
+  - Tropical forests
+  - Wood productivity
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T08:04:03Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3247484.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3247484.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3247484
+doi: 10.5281/zenodo.3247484
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter recorded as depth only.
+  screened_at: '2026-08-18T07:22:03Z'
+metadata:
+  title: How does forest conversion and fragmentation affect ant communities and the
+    ecosystem processes that they mediate?
+  authors:
+  - Fayle, Tom M
+  - Yusah, Kalsum M
+  - Ewers, Robert M
+  - Boyle, Michael J. W.
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3247484
+  keywords:
+  - Ants
+  - Foraging
+  - Bait removal
+  - SAFE project
+  - Formicidae
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:21:37Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3247638.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3247638.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3247638
+doi: 10.5281/zenodo.3247638
+screening:
+  decision: exclude
+  reason: duplicate_source
+  notes: Used intensively in litter mass and nutrient analyses.
+  screened_at: '2026-08-17T23:54:51Z'
+metadata:
+  title: Leaf litter decomposition in old-growth and selectively logged forest
+  authors:
+  - Both, Sabine
+  - Johnson, David
+  - Elias, Dafydd
+  - Ostle, Nick
+  - Majalap, Noreen
+  year: 2019
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3247638
+  keywords:
+  - decomposition
+  - leaf litter experiment
+  - leaf litter chemical composition
+  - old-growth forest
+  - selectively logged forest
+  provider: doi_content_search
+  retrieved_at: '2026-08-17T23:53:34Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3251886.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3251886.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3251886
+doi: 10.5281/zenodo.3251886
+screening:
+  decision: proceed
+  reason: relevant_validation_data
+  notes: Contains soil and litter C and N.
+  screened_at: '2026-08-18T07:12:35Z'
+metadata:
+  title: Soil greenhouse gas fluxes along transects from oil palm to riparian forests
+    in the SAFE landscape
+  authors:
+  - Drewer, Julia
+  - Kuling, Harry John
+  - Sentian, Justin
+  - Skiba, Ute
+  year: 2019
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3251886
+  keywords:
+  - HTMF
+  - river
+  - methane
+  - gas exchange
+  - SAFE project
+  - biogeochemistry
+  - greenhouse gases
+  - GHG
+  - nitrous oxide
+  - riparian
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:11:40Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3265703.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3265703.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3265703
+doi: 10.5281/zenodo.3265703
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter recorded as cover only.
+  screened_at: '2026-08-18T07:20:16Z'
+metadata:
+  title: Species richness, composition and microhabitat characteristics of non-volant
+    terrestrial mammals in disturbed habitats
+  authors:
+  - Wai, Leona
+  - Bernard, Henry
+  year: 2019
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3265703
+  keywords:
+  - Small mammals
+  - Habitat disturbance
+  - Microhabitat preferences
+  - Microhabitat use-pattern
+  - Species richness
+  - Non-volent mammals
+  - Oil palm
+  - Disturbed forest
+  - SAFE project
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:19:41Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3265721.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3265721.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3265721
+doi: 10.5281/zenodo.3265721
+screening:
+  decision: proceed
+  reason: relevant_validation_data
+  notes: Contains aboveground litter mass (leaf, reproduction, twig).
+  screened_at: '2026-08-17T23:37:41Z'
+metadata:
+  title: Fine litter dynamics
+  authors:
+  - Turner, Edgar
+  - Ewers, Robert M
+  - Nilus, Reuben
+  year: 2019
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3265721
+  keywords:
+  - Leaf litter
+  - Biomass
+  - Fine leaf litter
+  - Wet weight
+  - Dry weight
+  - SAFE Project
+  - Leaves
+  provider: doi_content_search
+  retrieved_at: '2026-08-17T23:35:11Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3354068.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3354068.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3354068
+doi: 10.5281/zenodo.3354068
+screening:
+  decision: defer
+  reason: outside_module_scope
+  notes: Invertebrate samples. Litter keyword describes sampling approach.
+  screened_at: '2026-08-18T07:15:24Z'
+metadata:
+  title: Core - invert biomass + ordinal sort
+  authors:
+  - Sawang, Anati
+  - Sharp, Adam
+  - Chung, Arthur
+  - Ewers, Robert M
+  - Barclay, Max
+  year: 2019
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3354068
+  keywords:
+  - Insect sorting
+  - Core data
+  - SAFE project
+  - Insect trapping
+  - Beetles
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:15:02Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3698114.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3698114.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3698114
+doi: 10.5281/zenodo.3698114
+screening:
+  decision: exclude
+  reason: duplicate_source
+  notes: Usable data are duplicates of drewer_2019.
+  screened_at: '2026-08-18T07:17:52Z'
+metadata:
+  title: Soil VOC emission rates and associated parameters from forest and oil palm
+    in the SAFE landscape
+  authors:
+  - Drewer, Julia
+  - Leduning, Melissa
+  - Sentian, Justin
+  - Skiba, Ute
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3698114
+  keywords:
+  - HTMF
+  - soil
+  - monoterpenes
+  - gas exchange
+  - SAFE project
+  - biogeochemistry
+  - VOC
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:15:41Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3908128.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3908128.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3908128
+doi: 10.5281/zenodo.3908128
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Litter recorded as cover only.
+  screened_at: '2026-08-18T07:21:27Z'
+metadata:
+  title: Importance of riparian reserves and other forest fragments for small mammal
+    diversity in disturbed and converted forest landscapes
+  authors:
+  - Bernard, Henry
+  - Hee, Kueh Boon
+  - Wong, Anna
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3908128
+  keywords:
+  - small mammals
+  - SAFE project
+  - rats
+  - squirrels
+  - tree shrews
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:21:00Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3948442.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3948442.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3948442
+doi: 10.5281/zenodo.3948442
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Bacteria keyword is about bacterial killing activity in bats.
+  screened_at: '2026-08-18T07:55:52Z'
+metadata:
+  title: Resilience and virus ecology of paleotropical bats
+  authors:
+  - Seltmann, Anne
+  - Corman, Victor M
+  - Rasche, Andrea
+  - Drosten, Christian
+  - Courtiol, Alexandre
+  - Czirjak, Gabor A
+  - Bernard, Henry
+  - Struebig, Matthew
+  - Voigt, Christian
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3948442
+  keywords:
+  - Bats
+  - Harp trapping
+  - Anthropogenic disturbance
+  - body mass
+  - chronic stress
+  - fragmentation
+  - white blood cell count
+  - coronaviruses
+  - astroviruses
+  - coinfection
+  - habitat fragmentation
+  - human-modified landscapes
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:55:01Z'

--- a/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3975972.yaml
+++ b/data/derived/soil/validation/config/sources/doi-10-5281-zenodo-3975972.yaml
@@ -1,0 +1,26 @@
+schema_version: 1
+record_id: doi-10-5281-zenodo-3975972
+doi: 10.5281/zenodo.3975972
+screening:
+  decision: exclude
+  reason: no_relevant_variables
+  notes: Fungi keyword is about Cordyceps fungus.
+  screened_at: '2026-08-18T07:54:33Z'
+metadata:
+  title: The importance of vertebrates in regulating insect herbivory pressure along
+    a gradient of logging intensity in Sabah, Borneo
+  authors:
+  - Ewers, Robert M
+  - Gray, Ryan
+  year: 2020
+  journal: ~
+  publisher: Zenodo
+  url: https://zenodo.org/record/3975972
+  keywords:
+  - Fungus
+  - Ordinal composition
+  - Understory vegetation
+  - Trophic interactions
+  - Herbivory
+  provider: doi_content_search
+  retrieved_at: '2026-08-18T07:54:02Z'


### PR DESCRIPTION
This PR uses the improved pipeline in PR #522 to screen more datasets into the validation database. They are added as a bunch of screened YAMLs. 

I will add schema to the ones marked "proceed" in another upcoming PR.