### PR TITLE
adding imported file as metadata

### DIFF
--- a/templates/python_script_template.py
+++ b/templates/python_script_template.py
@@ -29,6 +29,12 @@ output_files:
       What the output file contains and its significance, are they used in any other
       scripts?
 
+imported_files:
+  - name: Imported script title
+     path: Relative repository path to the imported file
+     description: |
+     Why the script is sourced or imported.
+
 package_dependencies:
   - math
 


### PR DESCRIPTION
Our python scripts have not yet gotten a field for imported files in the metadata header. Adding this might help the user understand what the scripts do and add clarity. See #292 

Fixes #572